### PR TITLE
Interpolated constants

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -29,6 +29,7 @@ WriteMakefile(
         'IO::Uncompress::Inflate'    => 0,
         'IO::Uncompress::RawInflate' => 0,
         'IO::Uncompress::Bunzip2'    => '2.021',
+        'Readonly'                   => '1.00',
     },
     META_MERGE => {
 	resources => {

--- a/lib/HTTP/Status.pm
+++ b/lib/HTTP/Status.pm
@@ -11,6 +11,8 @@ require Exporter;
 @EXPORT_OK = qw(is_client_error is_server_error);
 $VERSION = "6.03";
 
+use Readonly;
+
 # Note also addition of mnemonics to @EXPORT below
 
 # Unmarked codes are from RFC 2616
@@ -87,6 +89,8 @@ while (($code, $message) = each %StatusCode) {
     $mnemonicCode .= "*RC_$message = \\&HTTP_$message;\n";  # legacy
     $mnemonicCode .= "push(\@EXPORT_OK, 'HTTP_$message');\n";
     $mnemonicCode .= "push(\@EXPORT, 'RC_$message');\n";
+    $mnemonicCode .= "Readonly::Scalar our \$HTTP_$message => $code;\n";
+    $mnemonicCode .= "push(\@EXPORT_OK, '\$HTTP_$message');\n";
 }
 eval $mnemonicCode; # only one eval for speed
 die if $@;
@@ -97,6 +101,7 @@ push(@EXPORT, "RC_MOVED_TEMPORARILY");
 
 %EXPORT_TAGS = (
    constants => [grep /^HTTP_/, @EXPORT_OK],
+   readonly  => [grep /^\$HTTP_/, @EXPORT_OK],
    is => [grep /^is_/, @EXPORT, @EXPORT_OK],
 );
 
@@ -206,6 +211,19 @@ tag to import them all.
    HTTP_BANDWIDTH_LIMIT_EXCEEDED        (509)
    HTTP_NOT_EXTENDED                    (510)
    HTTP_NETWORK_AUTHENTICATION_REQUIRED (511)
+
+You can use the C<:readonly> tag to import similarly named L<Readonly>
+variables, which can be interpolated in strings or used as hash keys:
+
+   $HTTP_CONTINUE                       (100)
+   $HTTP_SWITCHING_PROTOCOLS            (101)
+   $HTTP_PROCESSING                     (102)
+
+   $HTTP_OK                             (200)
+   $HTTP_CREATED                        (201)
+   $HTTP_ACCEPTED                       (202)
+
+et cetera...
 
 =head1 FUNCTIONS
 

--- a/t/headers.t
+++ b/t/headers.t
@@ -3,7 +3,7 @@
 use strict;
 use Test qw(plan ok);
 
-plan tests => 166;
+plan tests => 175;
 
 my($h, $h2);
 sub j { join("|", @_) }
@@ -167,7 +167,7 @@ ok(j($h->header_field_names), "Date");
 ok($h->header("Date") =~ /^[A-Z][a-z][a-z], \d\d .* GMT$/);
 {
     my $off = time - $h->date;
-    ok($off == 0 || $off == 1); 
+    ok($off == 0 || $off == 1);
 }
 
 if ($] < 5.006) {
@@ -376,7 +376,7 @@ F: foo<<
 EOT
 
 # Check for attempt to send a body
-$h = HTTP::Headers->new( 
+$h = HTTP::Headers->new(
     a => "foo\r\n\r\nevil body" ,
     b => "foo\015\012\015\012evil body" ,
     c => "foo\x0d\x0a\x0d\x0aevil body" ,

--- a/t/status.t
+++ b/t/status.t
@@ -1,9 +1,9 @@
 #!perl -w
 
 use Test;
-plan tests => 9;
+plan tests => 16;
 
-use HTTP::Status qw(:constants :is status_message);
+use HTTP::Status qw(:constants :readonly :is status_message);
 
 ok(HTTP_OK, 200);
 
@@ -14,6 +14,16 @@ ok(is_client_error(HTTP_I_AM_A_TEAPOT));
 ok(is_redirect(HTTP_MOVED_PERMANENTLY));
 
 ok(!is_success(HTTP_NOT_FOUND));
+
+ok($HTTP_OK, 200);
+
+ok(is_info($HTTP_CONTINUE));
+ok(is_success($HTTP_ACCEPTED));
+ok(is_error($HTTP_BAD_REQUEST));
+ok(is_client_error($HTTP_I_AM_A_TEAPOT));
+ok(is_redirect($HTTP_MOVED_PERMANENTLY));
+
+ok(!is_success($HTTP_NOT_FOUND));
 
 ok(status_message(0), undef);
 ok(status_message(200), "OK");


### PR DESCRIPTION
This adds a :readonly tag that provides readonly scalar variables for the mnemonics, e.g. $HTTP_OK. The advantage of these over standard constants is that they can be used as hash keys as well as interpolated in strings.
