### PR TITLE
Adding the optional ability to set the size of each file read when DYNAM...

### DIFF
--- a/lib/HTTP/Request/Common.pm
+++ b/lib/HTTP/Request/Common.pm
@@ -1,14 +1,15 @@
 package HTTP::Request::Common;
 
 use strict;
-use vars qw(@EXPORT @EXPORT_OK $VERSION $DYNAMIC_FILE_UPLOAD);
+use vars qw(@EXPORT @EXPORT_OK $VERSION $DYNAMIC_FILE_UPLOAD $DYNAMIC_FILE_UPLOAD_READ_SIZE);
 
 $DYNAMIC_FILE_UPLOAD ||= 0;  # make it defined (don't know why)
+$DYNAMIC_FILE_UPLOAD_READ_SIZE ||= 2048;
 
 require Exporter;
 *import = \&Exporter::import;
 @EXPORT =qw(GET HEAD PUT POST);
-@EXPORT_OK = qw($DYNAMIC_FILE_UPLOAD DELETE);
+@EXPORT_OK = qw($DYNAMIC_FILE_UPLOAD DELETE $DYNAMIC_FILE_UPLOAD_READ_SIZE);
 
 require HTTP::Request;
 use Carp();
@@ -255,7 +256,7 @@ sub form_data   # RFC1867
                     binmode($fh);
                 }
 		my $buflength = length $buf;
-		my $n = read($fh, $buf, 2048, $buflength);
+		my $n = read($fh, $buf, $DYNAMIC_FILE_UPLOAD_READ_SIZE, $buflength);
 		if ($n) {
 		    $buflength += $n;
 		    unshift(@parts, ["", $fh]);


### PR DESCRIPTION
...IC_FILE_UPLOAD is being used.

When I do large file uploads with $DYNAMIC_FILE_UPLOAD it's hard coded to read the file in 2048 byte chunks. I find that this makes for some very slow transfers. As a test I went in and modified to to send 64k chunks and the transfer was much faster.

I'm proposing a possible solution to allow the user to set the amount of bytes they want to read at a time from the file. I'm open to discussion or implementing other ways but this seems like it fits with the interface.
