### PR TITLE
New ref content

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,10 @@
+Michael Houghton (1):
+    Modified HTTP::Message::new to check $content to see if it is a ref.
+    If it is a ref, dereference it before doing utf8::downgrade on it.
+    This addresses issue #13 in GitHub
+
+_______________________________________________________________________________
+2015-04-23 HTTP-Message 6.07
 
 Added support for is_client_error, is_server_error to HTTP::Response
 (Karen Etheridge)

--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Michael Houghton (1):
     Modified HTTP::Message::new to check $content to see if it is a ref.
-    If it is a ref, dereference it before doing utf8::downgrade on it.
+    Use the content_ref method to add $content in properly if it is a ref.
     This addresses issue #13 in GitHub
 
 _______________________________________________________________________________

--- a/lib/HTTP/Message.pm
+++ b/lib/HTTP/Message.pm
@@ -2,7 +2,7 @@ package HTTP::Message;
 
 use strict;
 use vars qw($VERSION $AUTOLOAD);
-$VERSION = "6.07";
+$VERSION = "6.06";
 
 require HTTP::Headers;
 require Carp;
@@ -43,19 +43,22 @@ sub new
 	$header = HTTP::Headers->new;
     }
     if (defined $content) {
-        # POD says "should be bytes", but tests also use refs
-        my $dcontent = ref($content) ? $$content : $content;
         _utf8_downgrade($content);
-        $content = $dcontent;
     }
     else {
         $content = '';
     }
 
-    bless {
+    my $self = bless {
 	'_headers' => $header,
 	'_content' => $content,
     }, $class;
+    
+    # docs say content should be bytes, but refs are OK
+    # the code above does not downgrade a ref properly, so this will do the trick
+    $self->content_ref($content) if (ref($content));
+    
+    return $self;
 }
 
 

--- a/lib/HTTP/Message.pm
+++ b/lib/HTTP/Message.pm
@@ -2,7 +2,7 @@ package HTTP::Message;
 
 use strict;
 use vars qw($VERSION $AUTOLOAD);
-$VERSION = "6.06";
+$VERSION = "6.07";
 
 require HTTP::Headers;
 require Carp;
@@ -43,7 +43,10 @@ sub new
 	$header = HTTP::Headers->new;
     }
     if (defined $content) {
+        # POD says "should be bytes", but tests also use refs
+        my $dcontent = ref($content) ? $$content : $content;
         _utf8_downgrade($content);
+        $content = $dcontent;
     }
     else {
         $content = '';


### PR DESCRIPTION
Issue #13 in Github identified a problem when new() is passed $content as a ref. In particular, it seems that utf8_downgrade doesn't get properly done. My fix was to have new capture the new object and if the content is a ref, then call content_ref to set it using the existing logic.

