### PR TITLE
If an object is passed to HTTP::Request, it must provide a canonical()

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for HTTP-Message
 
 {{$NEXT}}
+    - If an object is passed to HTTP::Request, it must provide a canonical()
+      method (Olaf Alders)
 
 6.11   2015-09-09
     - fix an undefined value warning in HTTP::Headers::as_string

--- a/META.json
+++ b/META.json
@@ -66,6 +66,7 @@
             "PerlIO::encoding" : "0",
             "Test::More" : "0.88",
             "Time::Local" : "0",
+            "Try::Tiny" : "0",
             "perl" : "5.008001"
          }
       }

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -42,7 +42,8 @@ my %WriteMakefileArgs = (
   "TEST_REQUIRES" => {
     "PerlIO::encoding" => 0,
     "Test::More" => "0.88",
-    "Time::Local" => 0
+    "Time::Local" => 0,
+    "Try::Tiny" => 0
   },
   "VERSION" => "6.12",
   "test" => {
@@ -72,6 +73,7 @@ my %FallbackPrereqs = (
   "Storable" => 0,
   "Test::More" => "0.88",
   "Time::Local" => 0,
+  "Try::Tiny" => 0,
   "URI" => "1.10",
   "base" => 0,
   "strict" => 0,

--- a/cpanfile
+++ b/cpanfile
@@ -25,6 +25,7 @@ on 'test' => sub {
   requires "PerlIO::encoding" => "0";
   requires "Test::More" => "0.88";
   requires "Time::Local" => "0";
+  requires "Try::Tiny" => "0";
   requires "perl" => "5.008001";
 };
 

--- a/lib/HTTP/Request.pm
+++ b/lib/HTTP/Request.pm
@@ -65,7 +65,7 @@ sub uri
 	    Carp::croak("A URI can't be a " . ref($uri) . " reference")
 		if ref($uri) eq 'HASH' or ref($uri) eq 'ARRAY';
 	    Carp::croak("Can't use a " . ref($uri) . " object as a URI")
-		unless $uri->can('scheme');
+		unless $uri->can('scheme') && $uri->can('canonical');
 	    $uri = $uri->clone;
 	    unless ($HTTP::URI_CLASS eq "URI") {
 		# Argh!! Hate this... old LWP legacy!


### PR DESCRIPTION
I ran into this issue today when I tried to GET a Mojo::URL object.  No
error was thrown until HTTP::Request tried to call the canonical()
method on the object.  So, just checking if an object provides a
scheme() method is not enough.

It's quite likely it should check for other methods as well, but this does fix this one particular case.
