### PR TITLE
More content consistency, less undef content warning.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /MYMETA.*
 /HTTP-Message-*/
 /HTTP-Message-*.tar.gz
+**~

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: perl
+perl:
+  - "5.8"
+  - "5.10"
+  - "5.12"
+  - "5.14"
+  - "5.16"
+  - "5.18"
+  - "5.20"
+
+script:
+   - make distclean && prove -lr t/

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -4,3 +4,5 @@
 ^HTTP-Message-.*.tar.gz
 ^\.ackrc$
 ^test-
+^\.git.*
+^\.travis.yml

--- a/lib/HTTP/Message.pm
+++ b/lib/HTTP/Message.pm
@@ -143,11 +143,11 @@ sub _set_content {
     my $self = $_[0];
     _utf8_downgrade($_[1]);
     if (!ref($_[1]) && ref($self->{_content}) eq "SCALAR") {
-	${$self->{_content}} = $_[1];
+	${$self->{_content}} = defined( $_[1] ) ? $_[1] : '';
     }
     else {
 	die "Can't set content to be a scalar reference" if ref($_[1]) eq "SCALAR";
-	$self->{_content} = $_[1];
+	$self->{_content} = defined( $_[1] ) ? $_[1] : '';
 	delete $self->{_content_ref};
     }
     delete $self->{_parts} unless $_[2];
@@ -834,6 +834,9 @@ but it will make your program a whole character shorter :-)
 The content() method sets the raw content if an argument is given.  If no
 argument is given the content is not touched.  In either case the
 original raw content is returned.
+
+If the C<undef> argument is given, the content is reset to its default value,
+which is an empty string.
 
 Note that the content should be a string of bytes.  Strings in perl
 can contain characters outside the range of a byte.  The C<Encode>

--- a/t/distmanifest.t
+++ b/t/distmanifest.t
@@ -5,7 +5,9 @@ use Test::More;
 BEGIN {
     plan skip_all => 'these tests are for authors only!'
         unless -d '.git' || $ENV{AUTHOR_TESTING};
+
+    plan skip_all => 'these tests require Test::DistManifest'
+      unless eval{ require Test::DistManifest; };
 }
 
-use Test::DistManifest;
-manifest_ok();
+Test::DistManifest::manifest_ok();

--- a/t/message.t
+++ b/t/message.t
@@ -1,9 +1,11 @@
+#! perl -w
+
 use strict;
 use warnings;
 
 use Test::More;
 
-plan tests => 129;
+plan tests => 131;
 
 require HTTP::Message;
 use Config qw(%Config);
@@ -21,6 +23,17 @@ is($m->content, "");
 
 $m->header("Foo", 1);
 is($m->as_string, "Foo: 1\n\n");
+
+{
+    # A message with an undef set content
+    # will stay consistent and have empty string
+    # as a content
+    my $m = HTTP::Message->new();
+    $m->content(undef);
+    is($m->as_string, "\n");
+    is($m->content, "");
+}
+
 
 $m2 = HTTP::Message->new($m->headers);
 $m2->header(bar => 2);


### PR DESCRIPTION
Hi,

This pull request addresses the case where some client code would call $m->content(undef);

This used to cause the '_content' property to go 'undef' instead of keeping the default 'empty string' value, and subsequently generating warnings on 'to_string' for instance.

This fixes this issue by enforcing more consistency and setting the content to be an empty string when one calls $m->content(undef).

Additionally, this introduces fixes for the test suite (it now fully passes straight away), and some travis building, checking that this package remains compatible with perl >= 5.8: https://travis-ci.org/jeteve/http-message
