### PR TITLE
got rid of some indirect object notation

### DIFF
--- a/t/headers.t
+++ b/t/headers.t
@@ -304,9 +304,10 @@ like($@, qr/^Illegal field name '' at \Q$file\E line $line/);
 
 #---- old tests below -----
 
-$h = new HTTP::Headers
+$h = HTTP::Headers->new(
 	mime_version  => "1.0",
-	content_type  => "text/html";
+	content_type  => "text/html"
+);
 $h->header(URI => "http://www.oslonett.no/");
 
 is($h->header("MIME-Version"), "1.0");

--- a/t/response.t
+++ b/t/response.t
@@ -16,7 +16,7 @@ my $time = time;
 my $req = HTTP::Request->new(GET => 'http://www.sn.no');
 $req->date($time - 30);
 
-my $r = new HTTP::Response 200, "OK";
+my $r = HTTP::Response->new(200, "OK");
 $r->client_date($time - 20);
 $r->date($time - 25);
 $r->last_modified($time - 5000000);


### PR DESCRIPTION
There were only two places my quick grep found with indirect object notation.