### PR TITLE
fix content-type error where $h is a ref but not an array

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for HTTP-Message
 
+    - fix error where content-type header is ref but not an array
+
 6.11   2015-09-09
 
     - fix an undefined value warning in HTTP::Headers::as_string

--- a/lib/HTTP/Headers.pm
+++ b/lib/HTTP/Headers.pm
@@ -359,7 +359,7 @@ sub content_type_charset {
     my $self = shift;
     require HTTP::Headers::Util;
     my $h = $self->{'content-type'};
-    $h = $h->[0] if ref($h);
+    $h = $h->[0] if ref($h) eq 'ARRAY';
     $h = "" unless defined $h;
     my @v = HTTP::Headers::Util::split_header_words($h);
     if (@v) {


### PR DESCRIPTION
Ran into an odd error where $h was a reference, but not an array. This fix explicitly checks to see if $h is an array reference before dereferencing it.