### PR TITLE
Allow size limit of ->decoded_content

### DIFF
--- a/lib/HTTP/Message.pm
+++ b/lib/HTTP/Message.pm
@@ -6,6 +6,8 @@ use warnings;
 require HTTP::Headers;
 require Carp;
 
+use vars '$MAXIMUM_BODY_SIZE';
+
 my $CRLF = "\015\012";   # "\r\n" is not portable
 unless ($HTTP::URI_CLASS) {
     if ($ENV{PERL_HTTP_URI_CLASS}
@@ -51,9 +53,9 @@ sub new
     bless {
 	'_headers' => $header,
 	'_content' => $content,
+	'_max_body_size' => $HTTP::Message::MAXIMUM_BODY_SIZE,
     }, $class;
 }
-
 
 sub parse
 {
@@ -275,6 +277,25 @@ sub content_charset
     return undef;
 }
 
+sub max_body_size  {
+    my $self = $_[0];
+    if (defined(wantarray)) {
+	my $old = $self->{_max_body_size};
+	&_set_max_body_size if @_ > 1;
+	return $old;
+    }
+    if (@_ > 1) {
+	&_set_max_body_size;
+    }
+    else {
+	Carp::carp("Useless max_body_size call in void context") if $^W;
+    }
+}
+
+sub _set_max_body_size {
+    my $self = $_[0];
+	$self->{_max_body_size} = $_[1];
+}
 
 sub decoded_content
 {

--- a/lib/HTTP/Message.pm
+++ b/lib/HTTP/Message.pm
@@ -307,6 +307,14 @@ sub decoded_content
 	$content_ref = $self->content_ref;
 	die "Can't decode ref content" if ref($content_ref) ne "SCALAR";
 
+    my $content_limit = exists $opt{ max_body_size } ? $opt{ max_body_size }
+                      : defined $self->max_body_size ? $self->max_body_size
+                      : undef
+                      ;
+    my %limiter_options;
+    if( defined $content_limit ) {
+        %limiter_options = (LimitOutput => 1, Bufsize => $content_limit);
+    };
 	if (my $h = $self->header("Content-Encoding")) {
 	    $h =~ s/^\s+//;
 	    $h =~ s/\s+$//;
@@ -314,18 +322,55 @@ sub decoded_content
 		next unless $ce;
 		next if $ce eq "identity" || $ce eq "none";
 		if ($ce eq "gzip" || $ce eq "x-gzip") {
-		    require IO::Uncompress::Gunzip;
-		    my $output;
-		    IO::Uncompress::Gunzip::gunzip($content_ref, \$output, Transparent => 0)
-			or die "Can't gunzip content: $IO::Uncompress::Gunzip::GunzipError";
+            require Compress::Raw::Zlib; # 'WANT_GZIP_OR_ZLIB', 'Z_BUF_ERROR';
+
+            if( ! $content_ref_iscopy and keys %limiter_options) {
+                # Create a copy of the input because Zlib will overwrite it
+                # :-(
+                my $input = "$$content_ref";
+                $content_ref = \$input;
+                $content_ref_iscopy++;
+            };
+            my ($i, $status) = Compress::Raw::Zlib::Inflate->new(
+                %limiter_options,
+                ConsumeInput => 0, # overridden by Zlib if we have %limiter_options :-(
+                WindowBits => Compress::Raw::Zlib::WANT_GZIP_OR_ZLIB(),
+            );
+            #warn "Foo: $status";
+            my $res = $i->inflate( $content_ref, \my $output );
+            $res == Compress::Raw::Zlib::Z_BUF_ERROR()
+                and Carp::croak("Decoded content would be larger than $content_limit octets");
+               $res == Compress::Raw::Zlib::Z_OK()
+            or $res == Compress::Raw::Zlib::Z_STREAM_END()
+                or die "Can't gunzip content: $res";
 		    $content_ref = \$output;
 		    $content_ref_iscopy++;
 		}
 		elsif ($ce eq "x-bzip2" or $ce eq "bzip2") {
-		    require IO::Uncompress::Bunzip2;
-		    my $output;
-		    IO::Uncompress::Bunzip2::bunzip2($content_ref, \$output, Transparent => 0)
-			or die "Can't bunzip content: $IO::Uncompress::Bunzip2::Bunzip2Error";
+		    require Compress::Raw::Bzip2;
+            
+            if( ! $content_ref_iscopy ) { #and keys %limiter_options) {
+                # Create a copy of the input because Bzlib2 will overwrite it
+                # :-(
+                my $input = "$$content_ref";
+                $content_ref = \$input;
+                $content_ref_iscopy++;
+            };
+            my ($i, $status) = Compress::Raw::Bunzip2->new(
+                1, # appendInput
+                0, # consumeInput
+                0, # small
+                $limiter_options{ LimitOutput } || 0,
+            );
+            my $output;
+            $output = "\0" x $limiter_options{ Bufsize }
+                if $limiter_options{ Bufsize };
+            my $res = $i->bzinflate( $content_ref, \$output );
+            $res == Compress::Raw::Bzip2::BZ_OUTBUFF_FULL()
+                and Carp::croak("Decoded content would be larger than $content_limit octets");
+               $res == Compress::Raw::Bzip2::BZ_OK()
+            or $res == Compress::Raw::Bzip2::BZ_STREAM_END()
+                or die "Can't bunzip content: $res";
 		    $content_ref = \$output;
 		    $content_ref_iscopy++;
 		}

--- a/t/message-decode-bzipbomb.t
+++ b/t/message-decode-bzipbomb.t
@@ -1,0 +1,101 @@
+# https://rt.cpan.org/Public/Bug/Display.html?id=52572
+
+use strict;
+use warnings;
+
+use Test::More;
+plan tests => 10;
+
+use HTTP::Headers    qw( );
+use HTTP::Response   qw( );
+
+# Create a nasty bzip2 stream:
+my $size = 16 * 1024 * 1024;
+my $stream = "\0" x $size;
+
+# Compress that stream three times:
+my $compressed = $stream;
+for( 1..3 ) {
+    require IO::Compress::Bzip2;
+    my $last = $compressed;
+    IO::Compress::Bzip2::bzip2(\$last, \$compressed)
+        or die "Can't bzip2 content: $IO::Compress::Bzip2::Bzip2Error";
+    #diag sprintf "Encoded size %d bytes after round %d", length $compressed, $_;
+};
+
+my $body = $compressed;
+
+my $headers = HTTP::Headers->new(
+    Content_Type => "application/xml",
+    Content_Encoding => 'bzip2,bzip2,bzip2', # say my name three times
+);
+my $response = HTTP::Response->new(200, "OK", $headers, $body);
+
+my $len = length $response->decoded_content( raise_error => 1 );
+is($len, 16 * 1024 * 1024, "Self-test: The decoded content length is 16M as expected" );
+
+# Manual decompression check
+my $output = $compressed;
+for( 1..3 ) {
+    my $last = $output;
+    require Compress::Raw::Bzip2;
+    my ($i, $status) = Compress::Raw::Bunzip2->new(
+        1, # appendInput
+        0, # consumeInput
+        0, # small
+        1,
+    );
+    $output = "\0" x (1024*1024);
+    # Will modify $last, but we made a copy above
+    my $res = $i->bzinflate( \$last, \$output );
+};
+is length $output, 1024*1024, "We manually recreate the limited original stream";
+
+$headers = HTTP::Headers->new(
+    Content_Type => "application/xml",
+    Content_Encoding => 'bzip2,bzip2,bzip2', # say my name three times
+);
+
+$HTTP::Message::MAXIMUM_BODY_SIZE = 1024 * 1024;
+
+$response = HTTP::Response->new(200, "OK", $headers, $body);
+is $response->max_body_size, 1024*1024, "The default maximum body size holds";
+
+$response->max_body_size( 512*1024 );
+is $response->max_body_size, 512*1024, "We can change the maximum body size";
+
+my $content;
+my $lives = eval {
+    $content = $response->decoded_content( raise_error => 1 );
+    1;
+};
+my $err = $@;
+is $lives, undef, "We die when trying to decode something larger than our limit of 512k";
+
+$response->max_body_size(undef);
+is $response->max_body_size, undef, "We can remove the maximum size restriction";
+$lives = eval {
+    $content = $response->decoded_content( raise_error => 0 );
+    1;
+};
+is $lives, 1, "We don't die when trying to decode something larger than our global limit of 1M";
+is length $content, 16 * 1024*1024, "We get the full content";
+is $content, $stream, "We really get the full content";
+
+# The best usage of ->decoded_content:
+$lives = eval {
+    $content = $response->decoded_content(
+        raise_error => 1,
+        max_body_size => 512 * 1024 );
+    1;
+};
+$err = $@;
+is $lives, undef, "We die when trying to decode something larger than our limit of 512k";
+
+=head1 SEE ALSO
+
+L<https://security.stackexchange.com/questions/51071/zlib-deflate-decompression-bomb>
+
+L<http://www.aerasec.de/security/advisories/decompression-bomb-vulnerability.html>
+
+=cut

--- a/t/message-decode-zipbomb.t
+++ b/t/message-decode-zipbomb.t
@@ -1,0 +1,101 @@
+# https://rt.cpan.org/Public/Bug/Display.html?id=52572
+
+use strict;
+use warnings;
+
+use Test::More;
+plan tests => 9;
+
+use HTTP::Headers    qw( );
+use HTTP::Response   qw( );
+
+# Create a nasty gzip stream:
+my $size = 16 * 1024 * 1024;
+my $stream = "\0" x $size;
+
+# Compress that stream three times:
+my $compressed = $stream;
+for( 1..3 ) {
+    require IO::Compress::Gzip;
+    my $last = $compressed;
+    IO::Compress::Gzip::gzip(\$last, \$compressed, Level => 9, -Minimal => 1)
+        or die "Can't gzip content: $IO::Compress::Gzip::GzipError";
+    #diag sprintf "Encoded size %d bytes after round %d", length $compressed, $_;
+};
+
+my $body = $compressed;
+
+my $headers = HTTP::Headers->new(
+    Content_Type => "application/xml",
+    Content_Encoding => 'gzip,gzip,gzip', # say my name three times
+);
+my $response = HTTP::Response->new(200, "OK", $headers, $body);
+
+my $len = length $response->decoded_content;
+is($len, 16 * 1024 * 1024, "Self-test: The decoded content length is 16M as expected" );
+
+# Manual decompression check
+my $output = $compressed;
+for( 1..3 ) {
+    use Compress::Raw::Zlib 'WANT_GZIP_OR_ZLIB', 'Z_BUF_ERROR';
+    
+    my $last = $output;
+    require Compress::Raw::Zlib;
+    my ($i, $status) = Compress::Raw::Zlib::Inflate->new(
+        Bufsize => 1024*1024,
+        LimitOutput => 1,
+        WindowBits => WANT_GZIP_OR_ZLIB
+    );
+    $output = '';
+    # Will modify $last, but we made a copy above
+    my $res = $i->inflate( \$last, \$output );
+};
+
+$headers = HTTP::Headers->new(
+    Content_Type => "application/xml",
+    Content_Encoding => 'gzip, gzip, gzip' # say my name three times
+);
+
+$HTTP::Message::MAXIMUM_BODY_SIZE = 1024 * 1024;
+
+$response = HTTP::Response->new(200, "OK", $headers, $body);
+is $response->max_body_size, 1024*1024, "The default maximum body size holds";
+
+$response->max_body_size( 512*1024 );
+is $response->max_body_size, 512*1024, "We can change the maximum body size";
+
+my $content;
+my $lives = eval {
+    $content = $response->decoded_content( raise_error => 1 );
+    1;
+};
+my $err = $@;
+is $lives, undef, "We die when trying to decode something larger than our limit of 512k";
+
+$response->max_body_size(undef);
+is $response->max_body_size, undef, "We can remove the maximum size restriction";
+$lives = eval {
+    $content = $response->decoded_content( raise_error => 0 );
+    1;
+};
+is $lives, 1, "We don't die when trying to decode something larger than our global limit of 1M";
+is length $content, 16 * 1024*1024, "We get the full content";
+is $content, $stream, "We really get the full content";
+
+# The best usage of ->decoded_content:
+$lives = eval {
+    $content = $response->decoded_content(
+        raise_error => 1,
+        max_body_size => 512 * 1024 );
+    1;
+};
+$err = $@;
+is $lives, undef, "We die when trying to decode something larger than our limit of 512k";
+
+=head1 SEE ALSO
+
+L<https://security.stackexchange.com/questions/51071/zlib-deflate-decompression-bomb>
+
+L<http://www.aerasec.de/security/advisories/decompression-bomb-vulnerability.html>
+
+=cut


### PR DESCRIPTION
To limit resource consumption when calling ->decoded_content, this change introduces an option to specify the maximum size ->decoded_content should decompress.

This prevents zip bombs from consuming available memory on machines.