### PR TITLE
More tests

### DIFF
--- a/lib/HTTP/Message.pm
+++ b/lib/HTTP/Message.pm
@@ -428,7 +428,7 @@ sub decodable
     };
     eval {
         require IO::Uncompress::Bunzip2;
-        push(@enc, "x-bzip2");
+        push(@enc, "x-bzip2", "bzip2");
     };
     # we don't care about announcing the 'identity', 'base64' and
     # 'quoted-printable' stuff
@@ -460,7 +460,7 @@ sub encode
 
     my $content = $self->content;
     for my $encoding (@enc) {
-	if ($encoding eq "identity") {
+	if ($encoding eq "identity" || $encoding eq "none") {
 	    # nothing to do
 	}
 	elsif ($encoding eq "base64") {
@@ -481,7 +481,7 @@ sub encode
 		or die "Can't deflate content: $IO::Compress::Deflate::DeflateError";
 	    $content = $output;
 	}
-	elsif ($encoding eq "x-bzip2") {
+	elsif ($encoding eq "x-bzip2" || $encoding eq "bzip2") {
 	    require IO::Compress::Bzip2;
 	    my $output;
 	    IO::Compress::Bzip2::bzip2(\$content, \$output)

--- a/lib/HTTP/Request.pm
+++ b/lib/HTTP/Request.pm
@@ -18,6 +18,7 @@ sub new
 sub parse
 {
     my($class, $str) = @_;
+    Carp::carp('Undefined argument to parse()') if $^W && ! defined $str;
     my $request_line;
     if (defined $str && $str =~ s/^(.*)\n//) {
 	$request_line = $1;
@@ -30,7 +31,7 @@ sub parse
     my $self = $class->SUPER::parse($str);
     if (defined $request_line) {
         my($method, $uri, $protocol) = split(' ', $request_line);
-        $self->method($method) if defined($method);
+        $self->method($method);
         $self->uri($uri) if defined($uri);
         $self->protocol($protocol) if $protocol;
     }

--- a/lib/HTTP/Request.pm
+++ b/lib/HTTP/Request.pm
@@ -19,7 +19,7 @@ sub parse
 {
     my($class, $str) = @_;
     my $request_line;
-    if ($str =~ s/^(.*)\n//) {
+    if (defined $str && $str =~ s/^(.*)\n//) {
 	$request_line = $1;
     }
     else {
@@ -28,10 +28,12 @@ sub parse
     }
 
     my $self = $class->SUPER::parse($str);
-    my($method, $uri, $protocol) = split(' ', $request_line);
-    $self->method($method) if defined($method);
-    $self->uri($uri) if defined($uri);
-    $self->protocol($protocol) if $protocol;
+    if (defined $request_line) {
+        my($method, $uri, $protocol) = split(' ', $request_line);
+        $self->method($method) if defined($method);
+        $self->uri($uri) if defined($uri);
+        $self->protocol($protocol) if $protocol;
+    }
     $self;
 }
 

--- a/lib/HTTP/Response.pm
+++ b/lib/HTTP/Response.pm
@@ -22,7 +22,7 @@ sub parse
 {
     my($class, $str) = @_;
     my $status_line;
-    if ($str =~ s/^(.*)\n//) {
+    if (defined $str && $str =~ s/^(.*)\n//) {
 	$status_line = $1;
     }
     else {
@@ -31,16 +31,18 @@ sub parse
     }
 
     my $self = $class->SUPER::parse($str);
-    my($protocol, $code, $message);
-    if ($status_line =~ /^\d{3} /) {
-       # Looks like a response created by HTTP::Response->new
-       ($code, $message) = split(' ', $status_line, 2);
-    } else {
-       ($protocol, $code, $message) = split(' ', $status_line, 3);
+    if (defined $status_line) {
+        my($protocol, $code, $message);
+        if ($status_line =~ /^\d{3} /) {
+           # Looks like a response created by HTTP::Response->new
+           ($code, $message) = split(' ', $status_line, 2);
+        } else {
+           ($protocol, $code, $message) = split(' ', $status_line, 3);
+        }
+        $self->protocol($protocol) if $protocol;
+        $self->code($code) if defined($code);
+        $self->message($message) if defined($message);
     }
-    $self->protocol($protocol) if $protocol;
-    $self->code($code) if defined($code);
-    $self->message($message) if defined($message);
     $self;
 }
 

--- a/lib/HTTP/Response.pm
+++ b/lib/HTTP/Response.pm
@@ -31,7 +31,7 @@ sub parse
 	$str = "";
     }
 
-    $status_line =~ s/\r\z//;
+    $status_line =~ s/\r\z// if defined $status_line;
 
     my $self = $class->SUPER::parse($str);
     if (defined $status_line) {

--- a/lib/HTTP/Response.pm
+++ b/lib/HTTP/Response.pm
@@ -21,6 +21,7 @@ sub new
 sub parse
 {
     my($class, $str) = @_;
+    Carp::carp('Undefined argument to parse()') if $^W && ! defined $str;
     my $status_line;
     if (defined $str && $str =~ s/^(.*)\n//) {
 	$status_line = $1;

--- a/t/common-req.t
+++ b/t/common-req.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use Test::More;
-plan tests => 61;
+plan tests => 64;
 
 use HTTP::Request::Common;
 
@@ -22,6 +22,16 @@ ok($r->uri->eq("http://www.sn.no"));
 
 is($r->header('If-Match'), "abc");
 is($r->header("from"), "aas\@sn.no");
+
+$r = HEAD "http://www.sn.no/",
+	Content => 'foo';
+is($r->content, 'foo');
+
+$r = HEAD "http://www.sn.no/",
+	Content => 'foo',
+	'Content-Length' => 50;
+is($r->content, 'foo');
+is($r->content_length, 50);
 
 $r = PUT "http://www.sn.no",
      Content => 'foo';

--- a/t/headers-auth.t
+++ b/t/headers-auth.t
@@ -3,7 +3,7 @@ use warnings;
 
 use Test::More;
 
-plan tests => 6;
+plan tests => 9;
 
 use HTTP::Response;
 use HTTP::Headers::Auth;
@@ -39,3 +39,10 @@ my $string = $res->as_string;
 like($string, qr/WWW-Authenticate: Basic realm="foo3", foo=33/);
 like($string, qr/WWW-Authenticate: Digest (nonce=bar, foo=foo|foo=foo, nonce=bar)/);
 
+$res = HTTP::Response->new(401);
+my @auth = $res->proxy_authenticate('foo');
+is_deeply(\@auth, []);
+@auth = $res->proxy_authenticate('foo', 'bar');
+is_deeply(\@auth, ['foo', {}]);
+@auth = $res->proxy_authenticate('foo', {'bar' => '_'});
+is_deeply(\@auth, ['foo', {}, 'bar', {}]);

--- a/t/headers-etag.t
+++ b/t/headers-etag.t
@@ -3,7 +3,7 @@ use warnings;
 
 use Test::More;
 
-plan tests => 4;
+plan tests => 11;
 
 require HTTP::Headers::ETag;
 
@@ -14,6 +14,17 @@ is($h->etag, qq("tag1"));
 
 $h->etag("w/tag2");
 is($h->etag, qq(W/"tag2"));
+
+$h->etag(" w/, weaktag");
+is($h->etag, qq(W/"", "weaktag"));
+my @list = $h->etag;
+is_deeply(\@list, ['W/""', '"weaktag"']);
+
+$h->etag(" w/");
+is($h->etag, qq(W/""));
+
+$h->etag(" ");
+is($h->etag, "");
 
 $h->if_match(qq(W/"foo", bar, baz), "bar");
 $h->if_none_match(333);
@@ -27,3 +38,8 @@ is($h->if_range, $t);
 
 note $h->as_string;
 
+@list = $h->if_range;
+is($#list, 0);
+is($list[0], $t);
+$h->if_range(undef);
+is($h->if_range, '');

--- a/t/headers-util.t
+++ b/t/headers-util.t
@@ -28,7 +28,7 @@ my @s_tests = (
     'basic; realm="\"foo\\\\bar\""'],
 );
 
-plan tests => @s_tests + 2;
+plan tests => @s_tests + 3;
 
 for (@s_tests) {
    my($arg, $expect) = @$_;
@@ -43,3 +43,4 @@ note "# Extra tests\n";
 # some extra tests
 is(join_header_words("foo" => undef, "bar" => "baz"), "foo; bar=baz");
 is(join_header_words(), "");
+is(join_header_words([]), "");

--- a/t/http-config.t
+++ b/t/http-config.t
@@ -22,9 +22,14 @@ is($conf->matching_items('foo', 'bar', 'baz'), 0);
 $conf->add({item => "http://www.example.com/foo", m_uri__HEAD => undef});
 is($conf->entries, 1);
 is($conf->matching_items("http://www.example.com/foo"), 0);
-is($conf->matching_items(0), 0);
-my $onematch = $conf->matching(0);
-ok(!defined $onematch);
+SKIP: {
+	my $res;
+	eval { $res = $conf->matching_items(0); };
+	skip "can fails on non-object", 2 if $@;
+	is($res, 0);
+	eval { $res = $conf->matching(0); };
+	ok(!defined $res);
+}
 
 $conf = HTTP::Config->new;
 

--- a/t/http-config.t
+++ b/t/http-config.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use Test::More;
-plan tests => 16;
+plan tests => 28;
 
 use HTTP::Config;
 
@@ -10,11 +10,21 @@ sub j { join("|", @_) }
 
 my $conf = HTTP::Config->new;
 ok($conf->empty);
+is($conf->entries, 0);
 $conf->add_item(42);
 ok(!$conf->empty);
+is($conf->entries, 1);
 is(j($conf->matching_items("http://www.example.com/foo")), 42);
 is(j($conf->remove_items), 42);
+is(j($conf->remove_items), '');
 is($conf->matching_items("http://www.example.com/foo"), 0);
+is($conf->matching_items('foo', 'bar', 'baz'), 0);
+$conf->add({item => "http://www.example.com/foo", m_uri__HEAD => undef});
+is($conf->entries, 1);
+is($conf->matching_items("http://www.example.com/foo"), 0);
+is($conf->matching_items(0), 0);
+my $onematch = $conf->matching(0);
+ok(!defined $onematch);
 
 $conf = HTTP::Config->new;
 
@@ -27,6 +37,10 @@ $conf->add_item("not secure", m_secure => 0);
 $conf->add_item("slash", m_host_port => "www.example.com:80", m_path_prefix => "/");
 $conf->add_item("u:p", m_host_port => "www.example.com:80", m_path_prefix => "/foo");
 $conf->add_item("success", m_code => "2xx");
+is($conf->find(m_domain => ".com")->{item}, '.com');
+my @found = $conf->find(m_domain => ".com");
+is($#found, 0);
+is($found[0]->{item}, '.com');
 
 use HTTP::Request;
 my $request = HTTP::Request->new(HEAD => "http://www.example.com/foo/bar");
@@ -70,6 +84,8 @@ is(j($conf->matching_items($response)), "xhtml|html|any");
 $response->content_type("text/html");
 is(j($conf->matching_items($response)), "HTML|html|text|any");
 
+$response->request(undef);
+is(j($conf->matching_items($response)), "HTML|html|text|any");
 
 {
     my @warnings;

--- a/t/message.t
+++ b/t/message.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Test::More;
 
-plan tests => 191;
+plan tests => 194;
 
 require HTTP::Message;
 use Config qw(%Config);
@@ -572,8 +572,15 @@ is($m->decode, 0);
 $m = HTTP::Message->new;
 ok($m->decode);
 {
-	local $SIG{__WARN__} = sub {};
+	my @warn;
+	local $SIG{__WARN__} = sub { push @warn, @_ };
+	local $^W = 0;
 	$m->content;
+	is($#warn, -1);
+	local $^W = 1;
+	$m->content;
+	is($#warn, 0);
+	like($warn[0], qr/Useless content call in void context/);
 }
 is($m->content(undef), '');
 eval { $m->content(\'foo'); };

--- a/t/message.t
+++ b/t/message.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Test::More;
 
-plan tests => 131;
+plan tests => 191;
 
 require HTTP::Message;
 use Config qw(%Config);
@@ -318,6 +318,19 @@ a<CR>
 --xYzZY--<CR>
 EOT
 
+$m = HTTP::Message->new(['Content-Type' => 'multipart/mixed']);
+$m->add_part(HTTP::Message->new([], 'foo and a lot more content'));
+is($m->header("Content-Type"), "multipart/mixed; boundary=xYzZY");
+@parts = $m->parts;
+is($parts[0]->content, 'foo and a lot more content');
+like($parts[0]->dump(maxlength => 4), qr/foo \.\.\./);
+like($parts[0]->dump(maxlength => 0), qr/foo and a lot/);
+eval { $m->encode; };
+like($@, qr/Can't encode multipart/);
+$m->content_type('message/http');
+eval { $m->encode; };
+like($@, qr/Can't encode message/);
+
 $m = HTTP::Message->new;
 $m->content_ref(\my $foo);
 is($m->content_ref, \$foo);
@@ -372,30 +385,44 @@ is($m->decoded_content, "fo=6F");
 $m->header("Content-Encoding", "quoted-printable");
 is($m->decoded_content, "foo");
 
-$m = HTTP::Message->new;
-$m->header("Content-Encoding", "gzip, base64");
-$m->content_type("text/plain; charset=UTF-8");
-$m->content("H4sICFWAq0ECA3h4eAB7v3u/R6ZCSUZqUarCoxm7uAAZKHXiEAAAAA==\n");
+for my $encoding (qw/gzip x-gzip/) {
+	$m = HTTP::Message->new;
+	$m->header("Content-Encoding", "$encoding, base64");
+	$m->content_type("text/plain; charset=UTF-8");
+	$m->content("H4sICFWAq0ECA3h4eAB7v3u/R6ZCSUZqUarCoxm7uAAZKHXiEAAAAA==\n");
 
-$@ = "";
-is(eval { $m->decoded_content }, "\x{FEFF}Hi there \x{263A}\n");
-is($@ || "", "");
-is($m->content, "H4sICFWAq0ECA3h4eAB7v3u/R6ZCSUZqUarCoxm7uAAZKHXiEAAAAA==\n");
+	$@ = "";
+	is(eval { $m->decoded_content }, "\x{FEFF}Hi there \x{263A}\n");
+	is($@ || "", "");
+	is($m->content, "H4sICFWAq0ECA3h4eAB7v3u/R6ZCSUZqUarCoxm7uAAZKHXiEAAAAA==\n");
 
-$m2 = $m->clone;
-ok($m2->decode);
-is($m2->header("Content-Encoding"), undef);
-like($m2->content, qr/Hi there/);
+	$m2 = $m->clone;
+	ok($m2->decode);
+	is($m2->header("Content-Encoding"), undef);
+	like($m2->content, qr/Hi there/);
 
-ok(grep { $_ eq "gzip" } $m->decodable);
+	ok(grep { $_ eq "$encoding" } $m->decodable);
 
-my $tmp = MIME::Base64::decode($m->content);
-$m->content($tmp);
-$m->header("Content-Encoding", "gzip");
-$@ = "";
-is(eval { $m->decoded_content }, "\x{FEFF}Hi there \x{263A}\n");
-is($@ || "", "");
-is($m->content, $tmp);
+	my $tmp = MIME::Base64::decode($m->content);
+	$m->content($tmp);
+	$m->header("Content-Encoding", "$encoding");
+	$@ = "";
+	is(eval { $m->decoded_content }, "\x{FEFF}Hi there \x{263A}\n");
+	is($@ || "", "");
+	is($m->content, $tmp);
+
+	my $m2 = HTTP::Message->new([
+	    "Content-Type" => "text/plain",
+	    ],
+	    "Hi there\n"
+	);
+	ok($m2->encode($encoding));
+	is($m2->header("Content-Encoding"), $encoding);
+	unlike($m2->content, qr/Hi there/);
+	is($m2->decoded_content, "Hi there\n");
+	ok($m2->decode);
+	is($m2->content, "Hi there\n");
+}
 
 $m->remove_header("Content-Encoding");
 $m->content("a\xFF");
@@ -450,14 +477,17 @@ is($m->dump(prefix => "| "), <<'EOT');
 | 
 | x\x9C\xF3H\xCD\xC9\xC9W(\xCF/\xCAIQ\4\0\35\t\4^
 EOT
-$m->encode("base64", "identity");
-is($m->as_string, <<'EOT');
-Content-Encoding: deflate, base64, identity
+for my $encoding (qw/identity none/) {
+	my $m2 = $m->clone;
+	$m2->encode("base64", $encoding);
+	is($m2->as_string, <<"EOT");
+Content-Encoding: deflate, base64, $encoding
 Content-Type: text/plain
 
 eJzzSM3JyVcozy/KSVEEAB0JBF4=
 EOT
-is($m->decoded_content, "Hello world!");
+	is($m2->decoded_content, "Hello world!");
+}
 
 # Raw RFC 1951 deflate
 $m = HTTP::Message->new([
@@ -471,37 +501,88 @@ ok(!$m->header("Client-Warning"));
 
 
 if (eval "require IO::Uncompress::Bunzip2") {
-    $m = HTTP::Message->new([
-        "Content-Type" => "text/plain",
-        "Content-Encoding" => "x-bzip2, base64",
-        ],
-	"QlpoOTFBWSZTWcvLx0QAAAHVgAAQYAAAQAYEkIAgADEAMCBoYlnQeSEMvxdyRThQkMvLx0Q=\n"
-    );
-    is($m->decoded_content, "Hello world!\n");
-    ok($m->decode);
-    is($m->content, "Hello world!\n");
-
-    if (eval "require IO::Compress::Bzip2") {
-	$m = HTTP::Message->new([
-	    "Content-Type" => "text/plain",
-	    ],
-	    "Hello world!"
-	);
-	ok($m->encode("x-bzip2"));
-	is($m->header("Content-Encoding"), "x-bzip2");
-	like($m->content, qr/^BZh.*\0/);
-	is($m->decoded_content, "Hello world!");
-	ok($m->decode);
-	is($m->content, "Hello world!");
-    }
-    else {
-	skip("Need IO::Compress::Bzip2", undef) for 1..6;
-    }
+	for my $encoding (qw/x-bzip2 bzip2/) {
+	    $m = HTTP::Message->new([
+	        "Content-Type" => "text/plain",
+	        "Content-Encoding" => "$encoding, base64",
+	        ],
+		"QlpoOTFBWSZTWcvLx0QAAAHVgAAQYAAAQAYEkIAgADEAMCBoYlnQeSEMvxdyRThQkMvLx0Q=\n"
+	    );
+	    is($m->decoded_content, "Hello world!\n");
+	    ok($m->decode);
+	    is($m->content, "Hello world!\n");
+	
+	    if (eval "require IO::Compress::Bzip2") {
+		$m = HTTP::Message->new([
+		    "Content-Type" => "text/plain",
+		    ],
+		    "Hello world!"
+		);
+		ok($m->encode($encoding));
+		is($m->header("Content-Encoding"), $encoding);
+		like($m->content, qr/^BZh.*\0/);
+		is($m->decoded_content, "Hello world!");
+		ok($m->decode);
+		is($m->content, "Hello world!");
+	    }
+	    else {
+		skip("Need IO::Compress::Bzip2", undef) for 1..6;
+	    }
+	}
 }
 else {
-    skip("Need IO::Uncompress::Bunzip2", undef) for 1..9;
+    skip("Need IO::Uncompress::Bunzip2", undef) for 1..18;
 }
 
 # test decoding of XML content
 $m = HTTP::Message->new(["Content-Type", "application/xml"], "\xFF\xFE<\0?\0x\0m\0l\0 \0v\0e\0r\0s\0i\0o\0n\0=\0\"\x001\0.\x000\0\"\0 \0e\0n\0c\0o\0d\0i\0n\0g\0=\0\"\0U\0T\0F\0-\x001\x006\0l\0e\0\"\0?\0>\0\n\0<\0r\0o\0o\0t\0>\0\xC9\0r\0i\0c\0<\0/\0r\0o\0o\0t\0>\0\n\0");
 is($m->decoded_content, "<?xml version=\"1.0\"?>\n<root>\xC9ric</root>\n");
+
+# DESTROY is a no-op
+$m->DESTROY;
+is($m->decoded_content, "<?xml version=\"1.0\"?>\n<root>\xC9ric</root>\n");
+
+$m = HTTP::Message->new([
+    "Content-Type" => "text/plain",
+    ],
+    "Hello World!\n"
+);
+is($m->content, "Hello World!\n");
+ok($m->encode());
+is($m->content, "Hello World!\n");
+is($m->encode("not-an-encoding"), 0);
+is($m->content, "Hello World!\n");
+ok($m->encode("rot13"));
+is($m->header("Content-Encoding"), "rot13");
+is($m->content, "Uryyb Jbeyq!\n");
+
+for my $encoding (qw/compress x-compress/) {
+    $m = HTTP::Message->new([
+        "Content-Type" => "text/plain",
+        "Content-Encoding" => $encoding,
+        ], "foo");
+	eval { $m->decoded_content(raise_error => 1); };
+	like($@, qr/Can't uncompress content/);
+}
+
+eval { $m = HTTP::Message->new('bad-header'); };
+like($@, qr/Bad header argument/);
+$m = HTTP::Message->new(['Content-Encoding' => 'zog']);
+is($m->decode, 0);
+$m = HTTP::Message->new;
+ok($m->decode);
+$m->content;
+is($m->content(undef), '');
+eval { $m->content(\'foo'); };
+like($@, qr/Can't set content to be a scalar reference/);
+
+$m = HTTP::Message->new (["Content-Type" => "text/plain",], "\xEF\xBB\xBFaa/");
+is($m->content_charset, "UTF-8");
+$m->content("\xFF\xFE\x00\x00aa/");
+is($m->content_charset, "UTF-32LE");
+$m->content("\x00\x00\xFE\xFFaa/");
+is($m->content_charset, "UTF-32BE");
+$m->content("\xFF\xFEaa/");
+is($m->content_charset, "UTF-16LE");
+$m->content("\xFE\xFFaa/");
+is($m->content_charset, "UTF-16BE");

--- a/t/message.t
+++ b/t/message.t
@@ -571,7 +571,10 @@ $m = HTTP::Message->new(['Content-Encoding' => 'zog']);
 is($m->decode, 0);
 $m = HTTP::Message->new;
 ok($m->decode);
-$m->content;
+{
+	local $SIG{__WARN__} = sub {};
+	$m->content;
+}
 is($m->content(undef), '');
 eval { $m->content(\'foo'); };
 like($@, qr/Can't set content to be a scalar reference/);

--- a/t/response.t
+++ b/t/response.t
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 use Test::More;
-plan tests => 29;
+plan tests => 64;
 
 use HTTP::Date;
 use HTTP::Request;
@@ -20,6 +20,7 @@ use HTTP::Response;
     is($req->is_error(), undef, 'Empty res: is_error');
     is($req->is_client_error(), undef, 'Empty res: is_client_error');
     is($req->is_server_error(), undef, 'Empty res: is_server_error');
+    is($req->filename(), undef, 'Empty res: filename');
 }
 
 my $time = time;
@@ -111,3 +112,62 @@ $r->push_header("Content-Base", "/2/;a=/foo/bar");
 is($r->base, "http://www.sn.no/2/;a=/foo/bar");
 $r->push_header("Content-Base", "/3/");
 is($r->base, "http://www.sn.no/2/;a=/foo/bar");
+
+$r2 = HTTP::Response->parse(undef);
+is($r2->code, undef);
+is($r2->message, undef);
+is($r2->protocol, undef);
+is($r2->status_line, "000 Unknown code");
+$r2->protocol('HTTP/1.0');
+is($r2->as_string("\n"), "HTTP/1.0 000 Unknown code\n\n");
+is($r2->dump, "HTTP/1.0 000 Unknown code\n\n(no content)\n");
+is($r2->current_age, 0);
+is($r2->freshness_lifetime, 3600);
+is($r2->freshness_lifetime(h_default => 900), 900);
+is($r2->freshness_lifetime(h_min => 7200), 7200);
+is($r2->freshness_lifetime(time => time), 3600);
+$r2->last_modified(time - 900);
+is($r2->freshness_lifetime, 90);
+is($r2->freshness_lifetime(h_lastmod_fraction => 0.2), 180);
+is($r2->freshness_lifetime(h_min => 300), 300);
+$r2->last_modified(time - 1000000);
+is($r2->freshness_lifetime(h_max => 7200), 7200);
+is($r2->freshness_lifetime(heuristic_expiry => 0), undef);
+is($r2->freshness_lifetime(heuristic_expiry => 1), 86400);
+ok($r2->is_fresh(time => time));
+ok($r2->fresh_until(time => time + 10));
+
+$r2->client_date(1);
+cmp_ok(abs(time - $r2->current_age), '<', 10); # Allow 10s for slow boxes
+is($r2->freshness_lifetime, 60);
+$r2->date(time);
+$r2->header(Age => -1);
+cmp_ok(abs(time - $r2->current_age), '<', 10); # Allow 10s for slow boxes
+is($r2->freshness_lifetime, 86400);
+$req = HTTP::Request->new;
+$r2->request($req);
+cmp_ok(abs(time - $r2->current_age), '<', 10); # Allow 10s for slow boxes
+$req->date(2);
+$r2->request($req);
+cmp_ok(abs(time - $r2->current_age), '<', 10); # Allow 10s for slow boxes
+
+$r2->header ('Content-Disposition' => "attachment; filename=foo.txt\n");
+is($r2->filename(), 'foo.txt');
+$r2->header ('Content-Disposition' => "attachment; filename=\n");
+is($r2->filename(), '');
+$r2->header ('Content-Disposition' => "attachment\n");
+is($r2->filename(), undef);
+$r2->header ('Content-Disposition' => "attachment; filename==?US-ASCII?B?Zm9vLnR4dA==?=\n");
+is($r2->filename(), 'foo.txt');
+$r2->header ('Content-Disposition' => "attachment; filename==?NOT-A-CHARSET?B?Zm9vLnR4dA==?=\n");
+is($r2->filename(), '=?NOT-A-CHARSET?B?Zm9vLnR4dA==?=');
+$r2->header ('Content-Disposition' => "attachment; filename==?US-ASCII?Z?Zm9vLnR4dA==?=\n");
+is($r2->filename(), '=?US-ASCII?Z?Zm9vLnR4dA==?=');
+$r2->header ('Content-Disposition' => "attachment; filename==?US-ASCII?Q?foo.txt?=\n");
+is($r2->filename(), 'foo.txt');
+$r2->remove_header ('Content-Disposition');
+$r2->header ('Content-Location' => '/tmp/baz.txt');
+is($r2->filename(), 'baz.txt');
+$r2->remove_header ('Content-Location');
+$req->uri('http://www.example.com/bar.txt');
+is($r2->filename(), 'bar.txt');

--- a/t/response.t
+++ b/t/response.t
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 use Test::More;
-plan tests => 67;
+plan tests => 68;
 
 use HTTP::Date;
 use HTTP::Request;

--- a/t/response.t
+++ b/t/response.t
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 use Test::More;
-plan tests => 64;
+plan tests => 67;
 
 use HTTP::Date;
 use HTTP::Request;
@@ -113,7 +113,17 @@ is($r->base, "http://www.sn.no/2/;a=/foo/bar");
 $r->push_header("Content-Base", "/3/");
 is($r->base, "http://www.sn.no/2/;a=/foo/bar");
 
-$r2 = HTTP::Response->parse(undef);
+{
+	my @warn;
+	local $SIG{__WARN__} = sub { push @warn, @_ };
+	local $^W = 0;
+	$r2 = HTTP::Response->parse( undef );
+	is($#warn, -1);
+	local $^W = 1;
+	$r2 = HTTP::Response->parse( undef );
+	is($#warn, 0);
+	like($warn[0], qr/Undefined argument to parse\(\)/);
+}
 is($r2->code, undef);
 is($r2->message, undef);
 is($r2->protocol, undef);

--- a/t/status.t
+++ b/t/status.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use Test::More;
-plan tests => 10;
+plan tests => 20;
 
 use HTTP::Status qw(:constants :is status_message);
 
@@ -19,3 +19,14 @@ ok(!is_success(HTTP_NOT_FOUND));
 
 is(status_message(0), undef);
 is(status_message(200), "OK");
+
+ok(!is_info(HTTP_NOT_FOUND));
+ok(!is_success(HTTP_NOT_FOUND));
+ok(!is_redirect(HTTP_NOT_FOUND));
+ok(!is_error(HTTP_CONTINUE));
+ok(!is_client_error(HTTP_CONTINUE));
+ok(!is_server_error(HTTP_NOT_FOUND));
+ok(!is_server_error(999));
+ok(!is_info(99));
+ok(!is_success(99));
+ok(!is_redirect(99));


### PR DESCRIPTION
Here are some more tests to push up the coverage.

While adding these I noticed that the checks for encodings in HTTP::Message were not consistent (eg. decode checked for "identity" or "none" but encode only for "identity"). This seemed to be an oversight so I have added in the aliases. This is the only change made to anything other than the test suite.

This work has been done as part of the [CPAN PR Challenge](http://cpan-prc.org). Thanks for taking part.