### PR TITLE
Allow decoding of application/json and application/javascript.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ The following methods are available:
 - $mess->decoded\_content( %options )
 
     Returns the content with any `Content-Encoding` undone and for textual content
-    the raw content encoded to Perl's Unicode strings.  If the `Content-Encoding`
-    or `charset` of the message is unknown this method will fail by returning
-    `undef`.
+    (text/*, XML, or JSON) the raw content encoded to Perl's Unicode strings.  If
+    the `Content-Encoding` or `charset` of the message is unknown this method will
+    fail by returning `undef`.
 
     The following options can be specified.
 

--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ The following methods are available:
 - $mess->decoded\_content( %options )
 
     Returns the content with any `Content-Encoding` undone and for textual content
-    (text/*, XML, or JSON) the raw content encoded to Perl's Unicode strings.  If
-    the `Content-Encoding` or `charset` of the message is unknown this method will
-    fail by returning `undef`.
+    (text/*, XML, JSON, or JavaScript) the raw content encoded to Perl's Unicode
+    strings.  If the `Content-Encoding` or `charset` of the message is unknown this
+    method will fail by returning `undef`.
 
     The following options can be specified.
 

--- a/lib/HTTP/Headers.pm
+++ b/lib/HTTP/Headers.pm
@@ -405,6 +405,13 @@ sub content_is_xml {
     return 0;
 }
 
+sub content_is_json {
+    my $ct = shift->content_type;
+    # text/json is not standard but still used by various servers.
+    # No issue including it as well.
+    return $ct eq 'application/json' || $ct eq 'text/json' || $ct =~ /\+json$/;
+}
+
 sub referer           {
     my $self = shift;
     if (@_ && $_[0] =~ /#/) {
@@ -736,6 +743,11 @@ content is XHTML.  This method can't be used to set Content-Type.
 
 Returns TRUE if the Content-Type header field indicate that the
 content is XML.  This method can't be used to set Content-Type.
+
+=item $h->content_is_json
+
+Returns TRUE if the Content-Type header field indicate that the
+content is JSON. This method can't be used to set Content-Type.
 
 =item $h->content_encoding
 

--- a/lib/HTTP/Headers.pm
+++ b/lib/HTTP/Headers.pm
@@ -412,6 +412,13 @@ sub content_is_json {
     return $ct eq 'application/json' || $ct eq 'text/json' || $ct =~ /\+json$/;
 }
 
+sub content_is_javascript {
+    my $ct = shift->content_type;
+    # text/javascript is obsolete in RFC4329 but still used.
+    # No issue including it as well.
+    return $ct eq 'application/javascript' || $ct eq 'text/javascript';
+}
+
 sub referer           {
     my $self = shift;
     if (@_ && $_[0] =~ /#/) {
@@ -748,6 +755,11 @@ content is XML.  This method can't be used to set Content-Type.
 
 Returns TRUE if the Content-Type header field indicate that the
 content is JSON. This method can't be used to set Content-Type.
+
+=item $h->content_is_javascript
+
+Returns TRUE if the Content-Type header field indicate that the
+content is JavaScript. This method can't be used to set Content-Type.
 
 =item $h->content_encoding
 

--- a/lib/HTTP/Message.pm
+++ b/lib/HTTP/Message.pm
@@ -351,7 +351,7 @@ sub decoded_content
 	    }
 	}
 
-	if ($self->content_is_text || (my $is_xml = $self->content_is_xml)) {
+	if ($self->content_is_text || (my $is_xml = $self->content_is_xml) || $self->content_is_json) {
 	    my $charset = lc(
 	        $opt{charset} ||
 		$self->content_type_charset ||
@@ -879,9 +879,9 @@ for details about how charset is determined.
 =item $mess->decoded_content( %options )
 
 Returns the content with any C<Content-Encoding> undone and for textual content
-the raw content encoded to Perl's Unicode strings.  If the C<Content-Encoding>
-or C<charset> of the message is unknown this method will fail by returning
-C<undef>.
+(text/*, XML, or JSON) the raw content encoded to Perl's Unicode strings.  If
+the C<Content-Encoding> or C<charset> of the message is unknown this method
+will fail by returning C<undef>.
 
 The following options can be specified.
 

--- a/lib/HTTP/Message.pm
+++ b/lib/HTTP/Message.pm
@@ -351,7 +351,7 @@ sub decoded_content
 	    }
 	}
 
-	if ($self->content_is_text || (my $is_xml = $self->content_is_xml) || $self->content_is_json) {
+	if ($self->content_is_text || (my $is_xml = $self->content_is_xml) || $self->content_is_json || $self->content_is_javascript) {
 	    my $charset = lc(
 	        $opt{charset} ||
 		$self->content_type_charset ||
@@ -879,9 +879,9 @@ for details about how charset is determined.
 =item $mess->decoded_content( %options )
 
 Returns the content with any C<Content-Encoding> undone and for textual content
-(text/*, XML, or JSON) the raw content encoded to Perl's Unicode strings.  If
-the C<Content-Encoding> or C<charset> of the message is unknown this method
-will fail by returning C<undef>.
+(text/*, XML, JSON, or JavaScript) the raw content encoded to Perl's Unicode
+strings.  If the C<Content-Encoding> or C<charset> of the message is unknown
+this method will fail by returning C<undef>.
 
 The following options can be specified.
 


### PR DESCRIPTION
This will, for application/json, detect if the file is UTF-8, UTF-16, or UTF-32, and try and return the content decoded. It will allow use of the charset/ default_charset options. Also allow text/json (if UTF-8).

It will also decode application/javascript which is permitted a charset parameter in RFC4329, so can be treated in the same way XML is.

New way of doing #90 which was too broad. Fixes #36. Fixes the main part of #72.