### PR TITLE
Add default status_message for unknown status codes (GH#105)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for HTTP-Message
 
 {{$NEXT}}
+    - Add default status_message for unknown status codes (GH#105) (Robert Rothenberg)
 
 6.16      2018-03-28 14:09:17Z
     - Update status codes to official IANA list (GH#100) (Theo van Hoesel)

--- a/lib/HTTP/Status.pm
+++ b/lib/HTTP/Status.pm
@@ -126,8 +126,14 @@ our %EXPORT_TAGS = (
    is => [grep /^is_/, @EXPORT, @EXPORT_OK],
 );
 
-
-sub status_message  ($) { $StatusCode{$_[0]}; }
+sub status_message ($) {
+    $StatusCode{ $_[0] } || is_info( $_[0] ) ? 'OK'
+      : is_success( $_[0] )      ? 'OK'
+      : is_redirect( $_[0] )     ? 'Redirect'
+      : is_client_error( $_[0] ) ? 'Client Error'
+      : is_server_error( $_[0] ) ? 'Server Error'
+      :                            undef;
+}
 
 sub is_info                 ($) { $_[0] && $_[0] >= 100 && $_[0] < 200; }
 sub is_success              ($) { $_[0] && $_[0] >= 200 && $_[0] < 300; }

--- a/t/status-message.t
+++ b/t/status-message.t
@@ -1,0 +1,15 @@
+use strict;
+use warnings;
+
+use Test::More;
+plan tests => 7;
+
+use HTTP::Status qw(status_message);
+
+is(status_message(0), undef);
+is(status_message(199), "OK");
+is(status_message(299), "OK");
+is(status_message(399), "Redirect");
+is(status_message(499), "Client Error");
+is(status_message(599), "Server Error");
+is(status_message(600), undef);


### PR DESCRIPTION
This fixes potential problems when new or unsupported status codes
are used by adding a default status code.

This change also adds tests.