### PR TITLE
Return the correct message for defined status codes

### DIFF
--- a/lib/HTTP/Status.pm
+++ b/lib/HTTP/Status.pm
@@ -127,7 +127,7 @@ our %EXPORT_TAGS = (
 );
 
 sub status_message ($) {
-    $StatusCode{ $_[0] } || is_info( $_[0] ) ? 'OK'
+    $StatusCode{ $_[0] } or is_info( $_[0] ) ? 'OK'
       : is_success( $_[0] )      ? 'OK'
       : is_redirect( $_[0] )     ? 'Redirect'
       : is_client_error( $_[0] ) ? 'Client Error'

--- a/t/status-message.t
+++ b/t/status-message.t
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 
 use Test::More;
-plan tests => 7;
 
 use HTTP::Status qw(status_message);
 
@@ -13,3 +12,8 @@ is(status_message(399), "Redirect");
 is(status_message(499), "Client Error");
 is(status_message(599), "Server Error");
 is(status_message(600), undef);
+
+
+is(status_message(404), "Not Found", "Found the 404");
+
+done_testing;


### PR DESCRIPTION
The problem is that the short hand if sets an OK message if the code
can be found in the %StatusCode hash, if it cannot be found it goes
through some additional checks. Use a different 'or' operator to fix the
glitch.

Fixes: GH #107