### PR TITLE
fix status_message only giving fallback values

### DIFF
--- a/lib/HTTP/Status.pm
+++ b/lib/HTTP/Status.pm
@@ -127,12 +127,15 @@ our %EXPORT_TAGS = (
 );
 
 sub status_message ($) {
-    $StatusCode{ $_[0] } || is_info( $_[0] ) ? 'OK'
-      : is_success( $_[0] )      ? 'OK'
-      : is_redirect( $_[0] )     ? 'Redirect'
-      : is_client_error( $_[0] ) ? 'Client Error'
-      : is_server_error( $_[0] ) ? 'Server Error'
-      :                            undef;
+    $StatusCode{ $_[0] }
+      || (
+          is_info( $_[0] )         ? 'OK'
+        : is_success( $_[0] )      ? 'OK'
+        : is_redirect( $_[0] )     ? 'Redirect'
+        : is_client_error( $_[0] ) ? 'Client Error'
+        : is_server_error( $_[0] ) ? 'Server Error'
+        :                            undef
+      );
 }
 
 sub is_info                 ($) { $_[0] && $_[0] >= 100 && $_[0] < 200; }

--- a/t/status-message.t
+++ b/t/status-message.t
@@ -2,14 +2,16 @@ use strict;
 use warnings;
 
 use Test::More;
-plan tests => 7;
+plan tests => 9;
 
 use HTTP::Status qw(status_message);
 
 is(status_message(0), undef);
+is(status_message(100), "Continue");
 is(status_message(199), "OK");
 is(status_message(299), "OK");
 is(status_message(399), "Redirect");
 is(status_message(499), "Client Error");
+is(status_message(504), "Gateway Timeout");
 is(status_message(599), "Server Error");
 is(status_message(600), undef);


### PR DESCRIPTION
The precedence of the operators was wrong, so all known status codes
were changed to 'OK'.

Alternative to #108, including tests.