### PR TITLE
Fix gitignore wildcard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-**~
+*~
 /.ackrc
 /blib/
 .build


### PR DESCRIPTION
Leading `**/`, trailing `**/`, and `/**/` are the only valid uses of `**` in git globs.