### PR TITLE
recreate http request in test (fixes #121)

### DIFF
--- a/t/http-config.t
+++ b/t/http-config.t
@@ -53,8 +53,8 @@ $request->header("User-Agent" => "Moz/1.0");
 
 is(j($conf->matching_items($request)), "u:p|slash|.com|GET|not secure|always");
 
-$request->method("HEAD");
-$request->uri->scheme("https");
+$request = HTTP::Request->new(HEAD => "https://www.example.com/foo/bar");
+$request->header("User-Agent" => "Moz/1.0");
 
 is(j($conf->matching_items($request)), ".com|GET|secure|always");
 


### PR DESCRIPTION
It appears this test is doing something with the HTTP::Request's URI object that doesn't like the canonical changes in https://github.com/libwww-perl/URI/pull/58. Just recreating the HTTP::Request object for the subsequent tests appears to fix the issue.