### PR TITLE
Support OPTIONS request method

### DIFF
--- a/lib/HTTP/Request/Common.pm
+++ b/lib/HTTP/Request/Common.pm
@@ -9,7 +9,7 @@ our $DYNAMIC_FILE_UPLOAD ||= 0;  # make it defined (don't know why)
 
 use Exporter 5.57 'import';
 
-our @EXPORT =qw(GET HEAD PUT PATCH POST);
+our @EXPORT =qw(GET HEAD PUT PATCH POST OPTIONS);
 our @EXPORT_OK = qw($DYNAMIC_FILE_UPLOAD DELETE);
 
 require HTTP::Request;
@@ -23,6 +23,7 @@ sub DELETE { _simple_req('DELETE', @_); }
 sub PATCH { request_type_with_data('PATCH', @_); }
 sub POST { request_type_with_data('POST', @_); }
 sub PUT { request_type_with_data('PUT', @_); }
+sub OPTIONS { request_type_with_data('OPTIONS', @_); }
 
 sub request_type_with_data
 {
@@ -314,6 +315,7 @@ __END__
   $ua->request(POST 'http://somewhere/foo', [foo => bar, bar => foo]);
   $ua->request(PATCH 'http://somewhere/foo', [foo => bar, bar => foo]);
   $ua->request(PUT 'http://somewhere/foo', [foo => bar, bar => foo]);
+  $ua->request(OPTIONS 'http://somewhere/foo', [foo => bar, bar => foo]);
 
 =head1 DESCRIPTION
 
@@ -389,6 +391,18 @@ The same as C<POST> below, but the method in the request is C<PATCH>.
 =item PUT $url, Header => Value,..., Content => $content
 
 The same as C<POST> below, but the method in the request is C<PUT>
+
+=item OPTIONS $url
+
+=item OPTIONS $url, Header => Value,...
+
+=item OPTIONS $url, $form_ref, Header => Value,...
+
+=item OPTIONS $url, Header => Value,..., Content => $form_ref
+
+=item OPTIONS $url, Header => Value,..., Content => $content
+
+The same as C<POST> below, but the method in the request is C<OPTIONS>
 
 =item POST $url
 

--- a/t/common-req.t
+++ b/t/common-req.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use Test::More;
-plan tests => 64;
+plan tests => 71;
 
 use HTTP::Request::Common;
 

--- a/t/common-req.t
+++ b/t/common-req.t
@@ -50,6 +50,23 @@ $r = PUT "http://www.sn.no",
      { foo => "bar" };
 is($r->content, "foo=bar");
 
+$r = OPTIONS "http://www.sn.no",
+     Content => 'foo';
+note $r->as_string, "\n";
+
+is($r->method, "OPTIONS");
+is($r->uri->host, "www.sn.no");
+
+ok(!defined($r->header("Content")));
+
+is(${$r->content_ref}, "foo");
+is($r->content, "foo");
+is($r->content_length, 3);
+
+$r = OPTIONS "http://www.sn.no",
+     { foo => "bar" };
+is($r->content, "foo=bar");
+
 $r = PATCH "http://www.sn.no",
      { foo => "bar" };
 is($r->content, "foo=bar");


### PR DESCRIPTION
As HTTP::Request support OPTIONS as well, this will be very helpful to be exported by HTTP::Request::Common as well
https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS