### PR TITLE
Support non-string header values that stringify

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for HTTP-Message
 
 {{$NEXT}}
     - Enable static install (GH#134) (Olaf Alders)
+    - Support stringifying non-string header values
 
 6.22      2020-02-24 18:58:07Z
     - Full release.  No changes since TRIAL release 6.21

--- a/dist.ini
+++ b/dist.ini
@@ -10,6 +10,7 @@ x_IRC = irc://irc.perl.org/#lwp
 x_MailingList = mailto:libwww@perl.org
 
 [Prereqs]
+Clone = 0
 Compress::Raw::Zlib = 0
 Encode = 3.01
 Encode::Locale = 1

--- a/dist.ini
+++ b/dist.ini
@@ -10,7 +10,6 @@ x_IRC = irc://irc.perl.org/#lwp
 x_MailingList = mailto:libwww@perl.org
 
 [Prereqs]
-Clone = 0
 Compress::Raw::Zlib = 0
 Encode = 3.01
 Encode::Locale = 1
@@ -22,6 +21,9 @@ LWP::MediaTypes = 6
 MIME::Base64 = 2.1
 perl = 5.008001
 URI = 1.10
+
+[Prereqs / Recommends]
+Clone = 0
 
 [@Author::OALDERS]
 ; all these tests are TODO

--- a/lib/HTTP/Headers.pm
+++ b/lib/HTTP/Headers.pm
@@ -299,8 +299,8 @@ sub _process_newline {
 
 
 
-if (eval { require Storable; 1 }) {
-    *clone = \&Storable::dclone;
+if (eval { require Clone; 1 }) {
+    *clone = \&Clone::clone;
 } else {
     *clone = sub {
 	my $self = shift;
@@ -527,7 +527,8 @@ means that you can update several fields with a single invocation.
 The $value argument may be a plain string or a reference to an array
 of strings for a multi-valued field. If the $value is provided as
 C<undef> then the field is removed.  If the $value is not given, then
-that header field will remain unchanged.
+that header field will remain unchanged. In addition to being a string,
+$value may be something that stringifies.
 
 The old value (or values) of the last of the header fields is returned.
 If no such field exists C<undef> will be returned.

--- a/t/headers.t
+++ b/t/headers.t
@@ -1,9 +1,12 @@
 use strict;
 use warnings;
 
+use lib 't/lib';
+
+use Secret ();
 use Test::More;
 
-plan tests => 188;
+plan tests => 189;
 
 my($h, $h2);
 sub j { join("|", @_) }
@@ -515,3 +518,9 @@ is_deeply(
     ],
 );
 
+subtest 'object that stringifies is a valid value' => sub {
+    my $h = HTTP::Headers->new;
+    $h->header('X-Password' => Secret->new('hunter2'));
+    my $h2 = $h->clone;
+    is($h2->as_string, "X-Password: hunter2\n", 'correct headers');
+};

--- a/t/lib/Secret.pm
+++ b/t/lib/Secret.pm
@@ -1,0 +1,18 @@
+package Secret;
+
+use strict;
+use warnings;
+
+use overload (
+    q{""}    => 'to_string',
+    fallback => 1,
+);
+
+sub new {
+    my ( $class, $s ) = @_;
+    return bless sub {$s}, $class;
+}
+
+sub to_string { shift->(); }
+
+1;


### PR DESCRIPTION
To avoid leaking secrets in stack traces, my team has started passing
secrets as blessed coderefs, similar to Secret.pm in this commit. One of
the spots we have a secret is in a header value.

I found that passing such an object to HTTP::Headers sort of works
already, but when LWP tries to use it in the request it calls clone()
which fails due to Storable throwing "Can't store CODE items".

Instead, this changes us to use Clone::clone which seems to provide
similar functionality while supporting this use case.

I'm not sure if there's important functional implications though between Storable and Clone.

Thank you!