### PR TITLE
Fix HTTP status descriptions and add 425 Too Early

### DIFF
--- a/lib/HTTP/Status.pm
+++ b/lib/HTTP/Status.pm
@@ -67,7 +67,7 @@ my %StatusCode = (
     422 => 'Unprocessable Entity',            # RFC 4918: WebDAV
     423 => 'Locked',                          # RFC 4918: WebDAV
     424 => 'Failed Dependency',               # RFC 4918: WebDAV
-#   425
+    425 => 'Too Early',                       # RFC 8470: Using Early Data in HTTP
     426 => 'Upgrade Required',
 #   427
     428 => 'Precondition Required',           # RFC 6585: Additional Codes
@@ -95,7 +95,6 @@ my %StatusCode = (
 %StatusCode = (
     %StatusCode,
     418 => 'I\'m a teapot',                   # RFC 2324: HTCPC/1.0  1-april
-    425 => 'Unordered Collection',            #           WebDAV Draft
     449 => 'Retry with',                      #           microsoft
     509 => 'Bandwidth Limit Exceeded',        #           Apache / cPanel
 );
@@ -127,8 +126,11 @@ push(@EXPORT, "RC_REQUEST_URI_TOO_LARGE");
 *RC_REQUEST_RANGE_NOT_SATISFIABLE = \&RC_RANGE_NOT_SATISFIABLE;
 push(@EXPORT, "RC_REQUEST_RANGE_NOT_SATISFIABLE");
 
-*RC_NO_CODE = \&RC_UNORDERED_COLLECTION;
+*RC_NO_CODE = \&RC_TOO_EARLY;
 push(@EXPORT, "RC_NO_CODE");
+
+*RC_UNORDERED_COLLECTION = \&RC_TOO_EARLY;
+push(@EXPORT, "RC_UNORDERED_COLLECTION");
 
 *HTTP_REQUEST_ENTITY_TOO_LARGE = \&HTTP_PAYLOAD_TOO_LARGE;
 push(@EXPORT_OK, "HTTP_REQUEST_ENTITY_TOO_LARGE");
@@ -139,8 +141,11 @@ push(@EXPORT_OK, "HTTP_REQUEST_URI_TOO_LARGE");
 *HTTP_REQUEST_RANGE_NOT_SATISFIABLE = \&HTTP_RANGE_NOT_SATISFIABLE;
 push(@EXPORT_OK, "HTTP_REQUEST_RANGE_NOT_SATISFIABLE");
 
-*HTTP_NO_CODE = \&HTTP_UNORDERED_COLLECTION;
+*HTTP_NO_CODE = \&HTTP_TOO_EARLY;
 push(@EXPORT_OK, "HTTP_NO_CODE");
+
+*HTTP_UNORDERED_COLLECTION = \&HTTP_TOO_EARLY;
+push(@EXPORT_OK, "HTTP_UNORDERED_COLLECTION");
 
 our %EXPORT_TAGS = (
    constants => [grep /^HTTP_/, @EXPORT_OK],
@@ -251,6 +256,7 @@ tag to import them all.
    HTTP_UNPROCESSABLE_ENTITY            (422)
    HTTP_LOCKED                          (423)
    HTTP_FAILED_DEPENDENCY               (424)
+   HTTP_TOO_EARLY                       (425)
    HTTP_UPGRADE_REQUIRED                (426)
    HTTP_PRECONDITION_REQUIRED           (428)
    HTTP_TOO_MANY_REQUESTS               (429)

--- a/lib/HTTP/Status.pm
+++ b/lib/HTTP/Status.pm
@@ -33,7 +33,7 @@ my %StatusCode = (
     207 => 'Multi-Status',                    # RFC 4918: WebDAV
     208 => 'Already Reported',                # RFC 5842: WebDAV bindings
 #   209 .. 225
-    226 => 'IM used',                         # RFC 3229: Delta encoding
+    226 => 'IM Used',                         # RFC 3229: Delta encoding
 #   227 .. 299
     300 => 'Multiple Choices',
     301 => 'Moved Permanently',
@@ -57,10 +57,10 @@ my %StatusCode = (
     410 => 'Gone',
     411 => 'Length Required',
     412 => 'Precondition Failed',             # RFC 7232: Conditional Request
-    413 => 'Request Entity Too Large',
-    414 => 'Request-URI Too Large',
+    413 => 'Payload Too Large',
+    414 => 'URI Too Long',
     415 => 'Unsupported Media Type',
-    416 => 'Request Range Not Satisfiable',   # RFC 7233: Range Requests
+    416 => 'Range Not Satisfiable',           # RFC 7233: Range Requests
     417 => 'Expectation Failed',
 #   418 .. 420
     421 => 'Misdirected Request',             # RFC 7540: HTTP/2
@@ -118,8 +118,29 @@ die if $@;
 *RC_MOVED_TEMPORARILY = \&RC_FOUND;  # 302 was renamed in the standard
 push(@EXPORT, "RC_MOVED_TEMPORARILY");
 
+*RC_REQUEST_ENTITY_TOO_LARGE = \&RC_PAYLOAD_TOO_LARGE;
+push(@EXPORT, "RC_REQUEST_ENTITY_TOO_LARGE");
+
+*RC_REQUEST_URI_TOO_LARGE = \&RC_URI_TOO_LONG;
+push(@EXPORT, "RC_REQUEST_URI_TOO_LARGE");
+
+*RC_REQUEST_RANGE_NOT_SATISFIABLE = \&RC_RANGE_NOT_SATISFIABLE;
+push(@EXPORT, "RC_REQUEST_RANGE_NOT_SATISFIABLE");
+
 *RC_NO_CODE = \&RC_UNORDERED_COLLECTION;
 push(@EXPORT, "RC_NO_CODE");
+
+*HTTP_REQUEST_ENTITY_TOO_LARGE = \&HTTP_PAYLOAD_TOO_LARGE;
+push(@EXPORT_OK, "HTTP_REQUEST_ENTITY_TOO_LARGE");
+
+*HTTP_REQUEST_URI_TOO_LARGE = \&HTTP_URI_TOO_LONG;
+push(@EXPORT_OK, "HTTP_REQUEST_URI_TOO_LARGE");
+
+*HTTP_REQUEST_RANGE_NOT_SATISFIABLE = \&HTTP_RANGE_NOT_SATISFIABLE;
+push(@EXPORT_OK, "HTTP_REQUEST_RANGE_NOT_SATISFIABLE");
+
+*HTTP_NO_CODE = \&HTTP_UNORDERED_COLLECTION;
+push(@EXPORT_OK, "HTTP_NO_CODE");
 
 our %EXPORT_TAGS = (
    constants => [grep /^HTTP_/, @EXPORT_OK],
@@ -221,10 +242,10 @@ tag to import them all.
    HTTP_GONE                            (410)
    HTTP_LENGTH_REQUIRED                 (411)
    HTTP_PRECONDITION_FAILED             (412)
-   HTTP_REQUEST_ENTITY_TOO_LARGE        (413)
-   HTTP_REQUEST_URI_TOO_LARGE           (414)
+   HTTP_PAYLOAD_TOO_LARGE               (413)
+   HTTP_URI_TOO_LONG                    (414)
    HTTP_UNSUPPORTED_MEDIA_TYPE          (415)
-   HTTP_REQUEST_RANGE_NOT_SATISFIABLE   (416)
+   HTTP_RANGE_NOT_SATISFIABLE           (416)
    HTTP_EXPECTATION_FAILED              (417)
    HTTP_MISDIRECTED REQUEST             (421)
    HTTP_UNPROCESSABLE_ENTITY            (422)

--- a/t/status.t
+++ b/t/status.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use Test::More;
-plan tests => 39;
+plan tests => 47;
 
 use HTTP::Status qw(:constants :is status_message);
 
@@ -14,6 +14,16 @@ ok(is_error(HTTP_BAD_REQUEST));
 ok(is_client_error(HTTP_I_AM_A_TEAPOT));
 ok(is_redirect(HTTP_MOVED_PERMANENTLY));
 ok(is_redirect(HTTP_PERMANENT_REDIRECT));
+
+# renamed status constants
+ok(is_error(HTTP_REQUEST_ENTITY_TOO_LARGE));
+ok(is_error(HTTP_PAYLOAD_TOO_LARGE));
+ok(is_error(HTTP_REQUEST_URI_TOO_LARGE));
+ok(is_error(HTTP_URI_TOO_LONG));
+ok(is_error(HTTP_REQUEST_RANGE_NOT_SATISFIABLE));
+ok(is_error(HTTP_RANGE_NOT_SATISFIABLE));
+ok(is_error(HTTP_NO_CODE));
+ok(is_error(HTTP_UNORDERED_COLLECTION));
 
 ok(!is_success(HTTP_NOT_FOUND));
 

--- a/t/status.t
+++ b/t/status.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use Test::More;
-plan tests => 47;
+plan tests => 48;
 
 use HTTP::Status qw(:constants :is status_message);
 
@@ -24,6 +24,7 @@ ok(is_error(HTTP_REQUEST_RANGE_NOT_SATISFIABLE));
 ok(is_error(HTTP_RANGE_NOT_SATISFIABLE));
 ok(is_error(HTTP_NO_CODE));
 ok(is_error(HTTP_UNORDERED_COLLECTION));
+ok(is_error(HTTP_TOO_EARLY));
 
 ok(!is_success(HTTP_NOT_FOUND));
 


### PR DESCRIPTION
The first commit fixes several status descriptions to match the canonical IANA list, and adds backcompat constants and tests for these renames, as well as a backcompat HTTP_NO_CODE constant that was missed in #100.

The second commit adds 425 Too Early and backcompat constants for the previous unofficial names, as it is now an official IANA status code from RFC 8470.