### PR TITLE
Corion/exporter inheritance

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for HTTP-Message
 
 {{$NEXT}}
+    - Don't inherit from Exporter anymore (Max Maischein)
+    - Remove superfluous Perl version requirement. This module requires
+      Perl 5.6 or newer. (Max Maischein)
 
 6.29      2021-03-06 04:50:34Z
     - fix issue with HTTP::Request internal cache for canonical url when using

--- a/lib/HTTP/Headers/Util.pm
+++ b/lib/HTTP/Headers/Util.pm
@@ -5,7 +5,7 @@ use warnings;
 
 our $VERSION = '6.30';
 
-use base 'Exporter';
+use Exporter 5.57 'import';
 
 our @EXPORT_OK=qw(split_header_words _split_header_words join_header_words);
 

--- a/lib/HTTP/Status.pm
+++ b/lib/HTTP/Status.pm
@@ -6,7 +6,6 @@ use warnings;
 our $VERSION = '6.30';
 
 use Exporter 5.57 'import';
-require 5.002;   # because we use prototypes
 
 our @EXPORT = qw(is_info is_success is_redirect is_error status_message);
 our @EXPORT_OK = qw(is_client_error is_server_error is_cacheable_by_default);

--- a/lib/HTTP/Status.pm
+++ b/lib/HTTP/Status.pm
@@ -5,9 +5,9 @@ use warnings;
 
 our $VERSION = '6.30';
 
+use Exporter 5.57 'import';
 require 5.002;   # because we use prototypes
 
-use base 'Exporter';
 our @EXPORT = qw(is_info is_success is_redirect is_error status_message);
 our @EXPORT_OK = qw(is_client_error is_server_error is_cacheable_by_default);
 


### PR DESCRIPTION
This patch does two things:

1) Remove the inheritance from Exporter in HTTP::Status

This might break usage like

    HTTP::Status->export_to_level(...)

2) Remove superfluous requirement of Perl 5.002

The use of `our` requires Perl 5.6 anyway