### PR TITLE
Support for Brotli encoding

### DIFF
--- a/lib/HTTP/Message.pm
+++ b/lib/HTTP/Message.pm
@@ -302,6 +302,14 @@ sub decoded_content
 		    $content_ref = \$output;
 		    $content_ref_iscopy++;
 		}
+		elsif ($ce eq 'br') {
+		    require IO::Uncompress::Brotli;
+		    my $bro = IO::Uncompress::Brotli->create;
+		    my $output = eval { $bro->decompress($$content_ref) };
+		    $@ and die "Can't unbrotli content: $@";
+		    $content_ref = \$output;
+		    $content_ref_iscopy++;
+		}
 		elsif ($ce eq "x-bzip2" or $ce eq "bzip2") {
 		    require IO::Uncompress::Bunzip2;
 		    my $output;
@@ -432,6 +440,10 @@ sub decodable
     eval {
         require IO::Uncompress::Bunzip2;
         push(@enc, "x-bzip2", "bzip2");
+    };
+    eval {
+        require IO::Uncompress::Brotli;
+        push(@enc, 'br');
     };
     # we don't care about announcing the 'identity', 'base64' and
     # 'quoted-printable' stuff


### PR DESCRIPTION
Implements and closes: https://github.com/libwww-perl/HTTP-Message/issues/163

No tests added.

Code example:
```perl
use 5.010;
use LWP::UserAgent;
use LWP::ConsoleLogger::Everywhere;

my $ua = LWP::UserAgent->new('agent' => "Mozilla/5.0");
$ua->default_header('Accept-Encoding' => scalar HTTP::Message::decodable());

my $resp = $ua->get("https://aur.archlinux.org/rpc.php?v=5&type=info&arg=perl-lwp-consolelogger");

if ($resp->is_success) {
    say length $resp->decoded_content;
}
```

Output:  [output.txt](https://github.com/libwww-perl/HTTP-Message/files/7039022/output.txt)
