### PR TITLE
Catch case of empty name/value in header words split.

### DIFF
--- a/lib/HTTP/Headers/Util.pm
+++ b/lib/HTTP/Headers/Util.pm
@@ -50,7 +50,7 @@ sub _split_header_words
 		push(@res, [@cur]) if @cur;
 		@cur = ();
 	    }
-	    elsif (s/^\s*;// || s/^\s+//) {
+	    elsif (s/^\s*;// || s/^\s+// || s/^=//) {
 		# continue
 	    }
 	    else {

--- a/t/headers-util.t
+++ b/t/headers-util.t
@@ -28,7 +28,7 @@ my @s_tests = (
     'basic; realm="\"foo\\\\bar\""'],
 );
 
-plan tests => @s_tests + 3;
+plan tests => @s_tests + 4;
 
 for (@s_tests) {
    my($arg, $expect) = @$_;
@@ -44,3 +44,5 @@ note "# Extra tests\n";
 is(join_header_words("foo" => undef, "bar" => "baz"), "foo; bar=baz");
 is(join_header_words(), "");
 is(join_header_words([]), "");
+# ignore bare =
+is_deeply(split_header_words("foo; =;bar=baz"), ["foo" => undef, "bar" => "baz"]);


### PR DESCRIPTION
Closes #167.  I think this is pretty straightforward.  When looking for `name=value`, the regexes miss the case where both are the empty string, that is, a bare `=` is in the header, which causes the function to fall through to the `die`.  I actually encountered such a header in the wild, bizarre though it may be.  This PR prevents an error by simply skipping over the `=` in this case.