### PR TITLE
HTTP::Request::Common does not put headers in an arrayref, unlike HTTP::Request

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for HTTP-Message
 
 {{$NEXT}}
+    - fixed examples in HTTP::Request::Common synopsis
 
 6.35      2021-11-11 22:10:31Z
     - Clarify documentation for decoded_content (GH#166) (Eric Wastl)

--- a/lib/HTTP/Request/Common.pm
+++ b/lib/HTTP/Request/Common.pm
@@ -313,10 +313,10 @@ __END__
   use HTTP::Request::Common;
   $ua = LWP::UserAgent->new;
   $ua->request(GET 'http://www.sn.no/');
-  $ua->request(POST 'http://somewhere/foo', [foo => bar, bar => foo]);
-  $ua->request(PATCH 'http://somewhere/foo', [foo => bar, bar => foo]);
-  $ua->request(PUT 'http://somewhere/foo', [foo => bar, bar => foo]);
-  $ua->request(OPTIONS 'http://somewhere/foo', [foo => bar, bar => foo]);
+  $ua->request(POST 'http://somewhere/foo', foo => bar, bar => foo);
+  $ua->request(PATCH 'http://somewhere/foo', foo => bar, bar => foo);
+  $ua->request(PUT 'http://somewhere/foo', foo => bar, bar => foo);
+  $ua->request(OPTIONS 'http://somewhere/foo', foo => bar, bar => foo);
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
this is straightforward, but a double-check would be appreciated :)