### PR TITLE
Extension of #164 with tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -57,7 +57,6 @@ jobs:
       image: perldocker/perl-tester:${{ matrix.perl-version }}
       env:
         AUTHOR_TESTING: 1
-        RELEASE_TESTING: 1
     steps:
       - uses: actions/download-artifact@master
         with:
@@ -117,7 +116,6 @@ jobs:
       - run: prove -l t xt
         env:
           AUTHOR_TESTING: 1
-          RELEASE_TESTING: 1
   test_windows:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -163,4 +161,3 @@ jobs:
       - run: prove -l t xt
         env:
           AUTHOR_TESTING: 1
-          RELEASE_TESTING: 1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -69,6 +69,7 @@ jobs:
           cpm install -g
           --cpanfile cpanfile
           --with-develop
+          --with-recommends
           --with-suggests
           --show-build-log-on-failure
       - name: Run Tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,6 +58,10 @@ jobs:
       env:
         AUTHOR_TESTING: 1
     steps:
+      - name: Decide if we need to install recommended modules
+        id: with-recommends
+        if: matrix.perl-version >= 5.14
+        run: echo '::set-output name=flag::--with-recommends'
       - uses: actions/download-artifact@master
         with:
           name: build_dir
@@ -68,7 +72,7 @@ jobs:
           cpm install -g
           --cpanfile cpanfile
           --with-develop
-          --with-recommends
+          ${{ steps.with-recommends.outputs.flag }}
           --with-suggests
           --show-build-log-on-failure
       - name: Run Tests
@@ -103,6 +107,10 @@ jobs:
         uses: shogo82148/actions-setup-perl@v1
         with:
           perl-version: ${{ matrix.perl-version }}
+      - name: Decide if we need to install recommended modules
+        id: with-recommends
+        if: matrix.perl-version >= 5.14
+        run: echo '::set-output name=flag::--with-recommends'
       - uses: actions/download-artifact@master
         with:
           name: build_dir
@@ -112,7 +120,13 @@ jobs:
         uses: perl-actions/install-with-cpm@v1
         with:
           cpanfile: "cpanfile"
-          args: "--with-develop --with-recommends --with-suggests --with-test --mirror https://cpan.metacpan.org --mirror http://cpan.cpantesters.org"
+          args: > 
+            --with-develop
+            ${{ steps.with-recommends.outputs.flag }}
+            --with-suggests
+            --with-test
+            --mirror https://cpan.metacpan.org
+            --mirror http://cpan.cpantesters.org
       - run: prove -l t xt
         env:
           AUTHOR_TESTING: 1

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /pm_to_blib
 *.sw*
 .tidyall.d
+.vscode/

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for HTTP-Message
 
 {{$NEXT}}
+    - Support for Brotli "br" encoding (GH#163) (trizen and Julien Fiegehenn)
     - Don't test Perl > 5.32 on Windows in GH Actions (GH#174) (Olaf Alders)
 
 6.36      2022-01-05 14:39:42Z

--- a/dist.ini
+++ b/dist.ini
@@ -15,7 +15,9 @@ Encode = 3.01
 Encode::Locale = 1
 Exporter = 5.57
 HTTP::Date = 6
+IO::Compress::Brotli = 0.004001
 IO::Compress::Bzip2 = 2.021
+IO::Uncompress::Brotli = 0.004001
 IO::Uncompress::Bunzip2 = 2.021
 LWP::MediaTypes = 6
 MIME::Base64 = 2.1
@@ -38,6 +40,12 @@ StaticInstall.dry_run = 0
 to_relationship = suggests
 copy_to = develop.requires
 module = Clone
+
+[Prereqs::Soften / Brotli]
+to_relationship = recommends
+copy_to = test.recommends
+module = IO::Compress::Brotli
+module = IO::Uncompress::Brotli
 
 [Test::Compile]
 bail_out_on_fail = 1

--- a/lib/HTTP/Message.pm
+++ b/lib/HTTP/Message.pm
@@ -503,6 +503,13 @@ sub encode
 		or die "Can't bzip2 content: $IO::Compress::Bzip2::Bzip2Error";
 	    $content = $output;
 	}
+	elsif ($encoding eq "br") {
+		require IO::Compress::Brotli;
+		my $output;
+		eval { $output = IO::Compress::Brotli::bro($content) }
+		or die "Can't brotli content: $@";
+		$content = $output;
+	}
 	elsif ($encoding eq "rot13") {  # for the fun of it
 	    $content =~ tr/A-Za-z/N-ZA-Mn-za-m/;
 	}
@@ -991,7 +998,7 @@ want to process its content as a string.
 Apply the given encodings to the content of the message.  Returns TRUE
 if successful. The "identity" (non-)encoding is always supported; other
 currently supported encodings, subject to availability of required
-additional modules, are "gzip", "deflate", "x-bzip2" and "base64".
+additional modules, are "gzip", "deflate", "x-bzip2", "base64" and "br".
 
 A successful call to this function will set the C<Content-Encoding>
 header.

--- a/lib/HTTP/Message.pm
+++ b/lib/HTTP/Message.pm
@@ -302,6 +302,14 @@ sub decoded_content
 		    $content_ref = \$output;
 		    $content_ref_iscopy++;
 		}
+		elsif ($ce eq 'br') {
+		    require IO::Uncompress::Brotli;
+		    my $bro = IO::Uncompress::Brotli->create;
+		    my $output = eval { $bro->decompress($$content_ref) };
+		    $@ and die "Can't unbrotli content: $@";
+		    $content_ref = \$output;
+		    $content_ref_iscopy++;
+		}
 		elsif ($ce eq "x-bzip2" or $ce eq "bzip2") {
 		    require IO::Uncompress::Bunzip2;
 		    my $output;
@@ -432,6 +440,10 @@ sub decodable
     eval {
         require IO::Uncompress::Bunzip2;
         push(@enc, "x-bzip2", "bzip2");
+    };
+    eval {
+        require IO::Uncompress::Brotli;
+        push(@enc, 'br');
     };
     # we don't care about announcing the 'identity', 'base64' and
     # 'quoted-printable' stuff

--- a/t/message-brotli.t
+++ b/t/message-brotli.t
@@ -1,0 +1,41 @@
+#! perl -w
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Needs 'IO::Compress::Brotli', 'IO::Uncompress::Brotli';
+
+require HTTP::Message;
+
+subtest "decoding" => sub {
+
+    my $m = HTTP::Message->new(
+        [
+            "Content-Type"     => "text/plain",
+            "Content-Encoding" => "br, base64",
+        ],
+        "CwaASGVsbG8gd29ybGQhCgM=\n"
+    );
+    is( $m->decoded_content, "Hello world!\n", "decoded_content() works" );
+    ok( $m->decode, "decode() works" );
+    is( $m->content, "Hello world!\n", "... and content() is correct" );
+};
+
+subtest "encoding" => sub {
+    my $m = HTTP::Message->new(
+        [
+            "Content-Type" => "text/plain",
+        ],
+        "Hello world!"
+    );
+    ok( $m->encode("br"), "set encoding to 'br" );
+    is( $m->header("Content-Encoding"),
+        "br", "... and Content-Encoding is set" );
+    isnt( $m->content, "Hello world!", "... and the content has changed" );
+    is( $m->decoded_content, "Hello world!", "decoded_content() works" );
+    ok( $m->decode, "decode() works" );
+    is( $m->content, "Hello world!", "... and content() is correct" );
+};
+
+done_testing;


### PR DESCRIPTION
I've taken #164 and added tests. I've also included encoding for Brotli, as we support this for other compressions.

However, I am not sure how to proceed with the dependencies. I made IO::Compress::Brotli and IO::Uncompress::Brotli (both are [from the same dist](https://metacpan.org/pod/IO::Compress::Brotli)) _suggests_ similar to Clone, but we require all of them for testing. The problem is that IO::Compress::Brotli requires Perl 5.14, so our github action for 5.10 and 5.12 would break.

I'm unsure how to proceed without causing breakage, so I've marked this as draft for now.

Closes #164 
Fixes #163