### PR TITLE
Noted that OPTIONS http method support was added in 6.21

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,8 @@ Revision history for HTTP-Message
 {{$NEXT}}
     - Replace "base" with "parent" (GH#176) (James Raspass)
     - Replace "print" with "note" in tests (GH#178) (James Raspass)
+    - Noted that OPTIONS supported was added in 6.1, to the doc
+      for HTTP::Request::Common. Addresses GH#177.
 
 6.37      2022-06-14 14:08:55Z
     - Support for Brotli "br" encoding (GH#163) (trizen and Julien Fiegehenn)
@@ -73,6 +75,7 @@ Revision history for HTTP-Message
     - Revert (GH#125) "try hard to make a usable file name" (GH#130) (Olaf
       Alders)
     - Fix JSON request encoding examples in POD (GH#126) (Michael Schout)
+    - Added support for OPTIONS requests.
 
 6.20      2019-02-05 01:46:39Z (TRIAL RELEASE)
     - Fix encoded file names when LC_ALL=C (GH#125) (Lars Dɪᴇᴄᴋᴏᴡ 迪拉斯)

--- a/lib/HTTP/Request/Common.pm
+++ b/lib/HTTP/Request/Common.pm
@@ -405,6 +405,10 @@ The same as C<POST> below, but the method in the request is C<PUT>
 
 The same as C<POST> below, but the method in the request is C<OPTIONS>
 
+This was added in version 6.21, so you should require that in your code:
+
+ use HTTP::Request::Common 6.21;
+
 =item POST $url
 
 =item POST $url, Header => Value,...


### PR DESCRIPTION
Retroactively added a note in the Changes section for 6.21, and added note to doc for OPTIONS in HTTP::Request::Common

This addresses #177 
