### PR TITLE
Always rely on Clone::clone() as the provider of HTTP::Headers::clone()

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 Revision history for HTTP-Message
 
 {{$NEXT}}
+    - Made the Clone module a hard requirement, so we don't have to
+      provide a fallback function for HTTP::Headers::clone().
+      We require at least Clone 0.46, as that release now supports
+      Perl back to 5.8.1, just like us. (GH#64) (Neil Bowers)
 
 6.43      2022-10-22 14:50:35Z
     - Remove dependency to IO::Uncompress::Bunzip2. (Michal Josef Spacek)

--- a/dist.ini
+++ b/dist.ini
@@ -22,6 +22,7 @@ LWP::MediaTypes = 6
 MIME::Base64 = 2.1
 perl = 5.008001
 URI = 1.10
+Clone = 0.46
 
 [@Author::OALDERS]
 ; all these tests are TODO
@@ -34,11 +35,6 @@ URI = 1.10
 -remove = Test::TidyAll
 StaticInstall.mode = on
 StaticInstall.dry_run = 0
-
-[Prereqs::Soften]
-to_relationship = suggests
-copy_to = develop.requires
-module = Clone
 
 [Prereqs::Soften / Brotli]
 to_relationship = recommends

--- a/lib/HTTP/Headers.pm
+++ b/lib/HTTP/Headers.pm
@@ -5,6 +5,7 @@ use warnings;
 
 our $VERSION = '6.44';
 
+use parent 'Clone';
 use Carp ();
 
 # The $TRANSLATE_UNDERSCORE variable controls whether '_' can be used
@@ -295,19 +296,6 @@ sub _process_newline {
     s/\n([^\040\t])/\n $1/g; # initial space for continuation
     s/\n/$endl/g;    # substitute with requested line ending
     $_;
-}
-
-
-
-if (eval { require Clone; 1 }) {
-    *clone = \&Clone::clone;
-} else {
-    *clone = sub {
-	my $self = shift;
-	my $clone = HTTP::Headers->new;
-	$self->scan(sub { $clone->push_header(@_);} );
-	$clone;
-    };
 }
 
 


### PR DESCRIPTION
This addresses GH#64, changing HTTP::Headers to rely on Clone to provide the `clone()` method.
