### PR TITLE
Increased read() buffer size from 2048 to 8192, when reading form data

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,9 @@ Revision history for HTTP-Message
 {{$NEXT}}
     - We now don't consider the Content-Location header when asked
       for the base URI. RFC 7231 says we shouldn't. (GH#51) (Neil Bowers)
+    - Increased the (max) buffer size for read() when processing form data,
+      from 2048 to 8192. This was suggested in RT#105184, as it improved
+      performance for them. (GH#59) (Neil Bowers)
 
 6.40      2022-10-12 15:45:52Z
     - Fixed two typos in the doc, originally reported by FatherC

--- a/lib/HTTP/Request/Common.pm
+++ b/lib/HTTP/Request/Common.pm
@@ -6,6 +6,7 @@ use warnings;
 our $VERSION = '6.41';
 
 our $DYNAMIC_FILE_UPLOAD ||= 0;  # make it defined (don't know why)
+our $READ_BUFFER_SIZE      = 8192;
 
 use Exporter 5.57 'import';
 
@@ -253,7 +254,7 @@ sub form_data   # RFC1867
                     binmode($fh);
                 }
 		my $buflength = length $buf;
-		my $n = read($fh, $buf, 2048, $buflength);
+		my $n = read($fh, $buf, $READ_BUFFER_SIZE, $buflength);
 		if ($n) {
 		    $buflength += $n;
 		    unshift(@parts, ["", $fh]);

--- a/t/common-req.t
+++ b/t/common-req.t
@@ -231,7 +231,7 @@ $_ = join("", @chunks);
 #note int(@chunks), " chunks, total size is ", length($_), " bytes\n";
 
 # should be close to expected size and number of chunks
-cmp_ok(abs(@chunks - 15), '<', 3);
+cmp_ok(abs(@chunks - 6), '<', 3);
 cmp_ok(abs(length($_) - 26589), '<', 20);
 
 $r = POST 'http://www.example.com';


### PR DESCRIPTION
This bumps the max buffer size for `read()` to 8192 from 2048, and also made it a package variable,
rather than hard-coded in-line.
This was suggested by a user, who said it gave "much better performance", in 2015.
RT#105184 ported over to #59 