### PR TITLE
add the 'status_code' function for getting all status codes as hash

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,8 @@ Revision history for HTTP-Message
 {{$NEXT}}
     - Allow for file ownership conflicts with Docker and GitHub Actions
       (GH#193) (Olaf Alders)
+    - Add the 'status_code' function for getting all status codes as hash
+      (GH#194) (Dai Okabayashi)
 
 6.44      2022-10-26 20:49:00Z
     - Made the Clone module a hard requirement, so we don't have to

--- a/lib/HTTP/Status.pm
+++ b/lib/HTTP/Status.pm
@@ -8,7 +8,7 @@ our $VERSION = '6.45';
 use Exporter 5.57 'import';
 
 our @EXPORT = qw(is_info is_success is_redirect is_error status_message);
-our @EXPORT_OK = qw(is_client_error is_server_error is_cacheable_by_default status_constant_name);
+our @EXPORT_OK = qw(is_client_error is_server_error is_cacheable_by_default status_constant_name status_codes);
 
 # Note also addition of mnemonics to @EXPORT below
 
@@ -168,6 +168,8 @@ sub is_cacheable_by_default ($) { $_[0] && ( $_[0] == 200 # OK
                                           || $_[0] == 501 # Not Implemented
                                             );
 }
+
+sub status_codes         { %StatusCode; }
 
 1;
 
@@ -340,6 +342,12 @@ Return TRUE if C<$code> indicates that a response is cacheable by default, and
 it can be reused by a cache with heuristic expiration. All other status codes
 are not cacheable by default. See L<RFC 7231 - HTTP/1.1 Semantics and Content,
 Section 6.1. Overview of Status Codes|https://tools.ietf.org/html/rfc7231#section-6.1>.
+
+This function is B<not> exported by default.
+
+=item status_codes
+
+Returns a hash mapping numerical HTTP status code (e.g. 200) to text status messages (e.g. "OK")
 
 This function is B<not> exported by default.
 

--- a/t/status.t
+++ b/t/status.t
@@ -2,9 +2,9 @@ use strict;
 use warnings;
 
 use Test::More;
-plan tests => 52;
+plan tests => 53;
 
-use HTTP::Status qw(:constants :is status_message status_constant_name);
+use HTTP::Status qw(:constants :is status_message status_constant_name status_codes);
 
 is(HTTP_OK, 200);
 
@@ -56,3 +56,6 @@ ok(!is_cacheable_by_default($_),
 is(status_constant_name(HTTP_OK), "HTTP_OK");
 is(status_constant_name(404),     "HTTP_NOT_FOUND");
 is(status_constant_name(999),     undef);
+
+my %status_codes = status_codes();
+is($status_codes{200}, status_message(200));


### PR DESCRIPTION
This is a cherry pick and squash of #34 (2016), which in turn is a rework of #4 (2013).

It would be great to merge this before it turns 10 in February. 😢 

Closes #34.