### PR TITLE
Update several status codes to RFC 9110

### DIFF
--- a/lib/HTTP/Status.pm
+++ b/lib/HTTP/Status.pm
@@ -40,6 +40,7 @@ my %StatusCode = (
     303 => 'See Other',
     304 => 'Not Modified',                    # RFC 7232: Conditional Request
     305 => 'Use Proxy',
+    306 => '(Unused)',                        # RFC 9110: Previously used and reserved
     307 => 'Temporary Redirect',
     308 => 'Permanent Redirect',              # RFC 7528: Permanent Redirect
 #   309 .. 399
@@ -56,14 +57,15 @@ my %StatusCode = (
     410 => 'Gone',
     411 => 'Length Required',
     412 => 'Precondition Failed',             # RFC 7232: Conditional Request
-    413 => 'Payload Too Large',
+    413 => 'Content Too Large',
     414 => 'URI Too Long',
     415 => 'Unsupported Media Type',
     416 => 'Range Not Satisfiable',           # RFC 7233: Range Requests
     417 => 'Expectation Failed',
-#   418 .. 420
+    418 => "I'm a teapot",                    # RFC 2324: RFC9110 reserved it
+#   419 .. 420
     421 => 'Misdirected Request',             # RFC 7540: HTTP/2
-    422 => 'Unprocessable Entity',            # RFC 4918: WebDAV
+    422 => 'Unprocessable Content',           # RFC 9110: WebDAV
     423 => 'Locked',                          # RFC 4918: WebDAV
     424 => 'Failed Dependency',               # RFC 4918: WebDAV
     425 => 'Too Early',                       # RFC 8470: Using Early Data in HTTP
@@ -88,21 +90,17 @@ my %StatusCode = (
 #   509
     510 => 'Not Extended',                    # RFC 2774: Extension Framework
     511 => 'Network Authentication Required', # RFC 6585: Additional Codes
-);
 
-my %StatusCodeName;
-
-# keep some unofficial codes that used to be in this distribution
-%StatusCode = (
-    %StatusCode,
-    418 => 'I\'m a teapot',                   # RFC 2324: HTCPC/1.0  1-april
+    # Keep some unofficial codes that used to be in this distribution
     449 => 'Retry with',                      #           microsoft
     509 => 'Bandwidth Limit Exceeded',        #           Apache / cPanel
 );
 
+my %StatusCodeName;
 my $mnemonicCode = '';
 my ($code, $message);
 while (($code, $message) = each %StatusCode) {
+    next if $message eq '(Unused)';
     # create mnemonic subroutines
     $message =~ s/I'm/I am/;
     $message =~ tr/a-z \-/A-Z__/;
@@ -121,7 +119,9 @@ die if $@;
 push(@EXPORT, "RC_MOVED_TEMPORARILY");
 
 my %compat = (
-    REQUEST_ENTITY_TOO_LARGE      => \&HTTP_PAYLOAD_TOO_LARGE,
+    UNPROCESSABLE_ENTITY          => \&HTTP_UNPROCESSABLE_CONTENT,
+    PAYLOAD_TOO_LARGE             => \&HTTP_CONTENT_TOO_LARGE,
+    REQUEST_ENTITY_TOO_LARGE      => \&HTTP_CONTENT_TOO_LARGE,
     REQUEST_URI_TOO_LARGE         => \&HTTP_URI_TOO_LONG,
     REQUEST_RANGE_NOT_SATISFIABLE => \&HTTP_RANGE_NOT_SATISFIABLE,
     NO_CODE                       => \&HTTP_TOO_EARLY,
@@ -242,13 +242,13 @@ tag to import them all.
    HTTP_GONE                            (410)
    HTTP_LENGTH_REQUIRED                 (411)
    HTTP_PRECONDITION_FAILED             (412)
-   HTTP_PAYLOAD_TOO_LARGE               (413)
+   HTTP_CONTENT_TOO_LARGE               (413)
    HTTP_URI_TOO_LONG                    (414)
    HTTP_UNSUPPORTED_MEDIA_TYPE          (415)
    HTTP_RANGE_NOT_SATISFIABLE           (416)
    HTTP_EXPECTATION_FAILED              (417)
    HTTP_MISDIRECTED REQUEST             (421)
-   HTTP_UNPROCESSABLE_ENTITY            (422)
+   HTTP_UNPROCESSABLE_CONTENT           (422)
    HTTP_LOCKED                          (423)
    HTTP_FAILED_DEPENDENCY               (424)
    HTTP_TOO_EARLY                       (425)

--- a/t/status.t
+++ b/t/status.t
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 
 use Test::More;
-plan tests => 53;
 
 use HTTP::Status qw(:constants :is status_message status_constant_name status_codes);
 
@@ -11,7 +10,6 @@ is(HTTP_OK, 200);
 ok(is_info(HTTP_CONTINUE));
 ok(is_success(HTTP_ACCEPTED));
 ok(is_error(HTTP_BAD_REQUEST));
-ok(is_client_error(HTTP_I_AM_A_TEAPOT));
 ok(is_redirect(HTTP_MOVED_PERMANENTLY));
 ok(is_redirect(HTTP_PERMANENT_REDIRECT));
 
@@ -25,6 +23,13 @@ ok(is_error(HTTP_RANGE_NOT_SATISFIABLE));
 ok(is_error(HTTP_NO_CODE));
 ok(is_error(HTTP_UNORDERED_COLLECTION));
 ok(is_error(HTTP_TOO_EARLY));
+ok(is_error(HTTP_UNPROCESSABLE_ENTITY));
+ok(is_error(HTTP_PAYLOAD_TOO_LARGE));
+
+# Have a sip and a great day
+ok(is_client_error(HTTP_I_AM_A_TEAPOT));
+ok(is_error(HTTP_I_AM_A_TEAPOT));
+is(status_message(418), "I'm a teapot");
 
 ok(!is_success(HTTP_NOT_FOUND));
 
@@ -59,3 +64,5 @@ is(status_constant_name(999),     undef);
 
 my %status_codes = status_codes();
 is($status_codes{200}, status_message(200));
+
+done_testing;


### PR DESCRIPTION
* 306 is officially reserved but unused
* 413 is called 'Content Too Large' in RFC 9110
* 418 is officially reserved, so let's make it official here too
* 422 is imported from WebDAV and named 'Unprocessable Content'.

Reference: https://www.rfc-editor.org/rfc/rfc9110.html#name-changes-from-rfc-7231