### PR TITLE
Tidy up some .pm and .t

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ You can run tests directly using the `prove` tool:
 
 ## Code style and tidying
 
-This distribution contains a `.perltidyrc` file in the root of the repository.
+This distribution contains a `perltidyrc` file in the root of the repository.
 Please install Perl::Tidy and use `perltidy` before submitting patches. However,
 as this is an old distribution and styling has changed somewhat over the years,
 please keep your tidying constrained to the portion of code or function in which
@@ -48,7 +48,7 @@ you're patching.
     $ rm my_tidy_copy.pm
 
 The above command, for example, would provide you with a copy of `Status.pm`
-that has been cleaned according to our `.perltidyrc` settings. You'd then look
+that has been cleaned according to our `perltidyrc` settings. You'd then look
 at the newly created `my_tidy_copy.pm` in the dist root and replace your work
 with the cleaned up copy if there are differences.
 

--- a/lib/HTTP/Headers/Auth.pm
+++ b/lib/HTTP/Headers/Auth.pm
@@ -7,8 +7,7 @@ our $VERSION = '7.01';
 
 use HTTP::Headers;
 
-package
-    HTTP::Headers;
+package HTTP::Headers;
 
 BEGIN {
     # we provide a new (and better) implementations below
@@ -18,83 +17,84 @@ BEGIN {
 
 require HTTP::Headers::Util;
 
-sub _parse_authenticate
-{
+sub _parse_authenticate {
     my @ret;
-    for (HTTP::Headers::Util::split_header_words(@_)) {
-	if (!defined($_->[1])) {
-	    # this is a new auth scheme
-	    push(@ret, shift(@$_) => {});
-	    shift @$_;
-	}
-	if (@ret) {
-	    # this a new parameter pair for the last auth scheme
-	    while (@$_) {
-		my $k = shift @$_;
-		my $v = shift @$_;
-	        $ret[-1]{$k} = $v;
-	    }
-	}
-	else {
-	    # something wrong, parameter pair without any scheme seen
-	    # IGNORE
-	}
+    for ( HTTP::Headers::Util::split_header_words(@_) ) {
+        if ( !defined( $_->[1] ) ) {
+
+            # this is a new auth scheme
+            push( @ret, shift(@$_) => {} );
+            shift @$_;
+        }
+        if (@ret) {
+
+            # this a new parameter pair for the last auth scheme
+            while (@$_) {
+                my $k = shift @$_;
+                my $v = shift @$_;
+                $ret[-1]{$k} = $v;
+            }
+        }
+        else {
+            # something wrong, parameter pair without any scheme seen
+            # IGNORE
+        }
     }
     @ret;
 }
 
-sub _authenticate
-{
-    my $self = shift;
+sub _authenticate {
+    my $self   = shift;
     my $header = shift;
-    my @old = $self->_header($header);
+    my @old    = $self->_header($header);
     if (@_) {
-	$self->remove_header($header);
-	my @new = @_;
-	while (@new) {
-	    my $a_scheme = shift(@new);
-	    if ($a_scheme =~ /\s/) {
-		# assume complete valid value, pass it through
-		$self->push_header($header, $a_scheme);
-	    }
-	    else {
-		my @param;
-		if (@new) {
-		    my $p = $new[0];
-		    if (ref($p) eq "ARRAY") {
-			@param = @$p;
-			shift(@new);
-		    }
-		    elsif (ref($p) eq "HASH") {
-			@param = %$p;
-			shift(@new);
-		    }
-		}
-		my $val = ucfirst(lc($a_scheme));
-		if (@param) {
-		    my $sep = " ";
-		    while (@param) {
-			my $k = shift @param;
-			my $v = shift @param;
-			if ($v =~ /[^0-9a-zA-Z]/ || lc($k) eq "realm") {
-			    # must quote the value
-			    $v =~ s,([\\\"]),\\$1,g;
-			    $v = qq("$v");
-			}
-			$val .= "$sep$k=$v";
-			$sep = ", ";
-		    }
-		}
-		$self->push_header($header, $val);
-	    }
-	}
+        $self->remove_header($header);
+        my @new = @_;
+        while (@new) {
+            my $a_scheme = shift(@new);
+            if ( $a_scheme =~ /\s/ ) {
+
+                # assume complete valid value, pass it through
+                $self->push_header( $header, $a_scheme );
+            }
+            else {
+                my @param;
+                if (@new) {
+                    my $p = $new[0];
+                    if ( ref($p) eq "ARRAY" ) {
+                        @param = @$p;
+                        shift(@new);
+                    }
+                    elsif ( ref($p) eq "HASH" ) {
+                        @param = %$p;
+                        shift(@new);
+                    }
+                }
+                my $val = ucfirst( lc($a_scheme) );
+                if (@param) {
+                    my $sep = " ";
+                    while (@param) {
+                        my $k = shift @param;
+                        my $v = shift @param;
+                        if ( $v =~ /[^0-9a-zA-Z]/ || lc($k) eq "realm" ) {
+
+                            # must quote the value
+                            $v =~ s,([\\\"]),\\$1,g;
+                            $v = qq("$v");
+                        }
+                        $val .= "$sep$k=$v";
+                        $sep = ", ";
+                    }
+                }
+                $self->push_header( $header, $val );
+            }
+        }
     }
     return unless defined wantarray;
-    wantarray ? _parse_authenticate(@old) : join(", ", @old);
+    wantarray ? _parse_authenticate(@old) : join( ", ", @old );
 }
 
-
-sub www_authenticate    { shift->_authenticate("WWW-Authenticate", @_)   }
-sub proxy_authenticate  { shift->_authenticate("Proxy-Authenticate", @_) }
+sub www_authenticate   { shift->_authenticate( "WWW-Authenticate",   @_ ) }
+sub proxy_authenticate { shift->_authenticate( "Proxy-Authenticate", @_ ) }
 
 1;

--- a/lib/HTTP/Headers/ETag.pm
+++ b/lib/HTTP/Headers/ETag.pm
@@ -55,9 +55,9 @@ sub if_range {
 # use it on C<ETag> and C<If-Range> entity tag values, because it will
 # normalize them to the common form.
 #
-#  entity-tag	  = [ weak ] opaque-tag
-#  weak		  = "W/"
-#  opaque-tag	  = quoted-string
+#  entity-tag = [ weak ] opaque-tag
+#  weak       = "W/"
+#  opaque-tag = quoted-string
 
 sub _split_etag_list {
     my (@val) = @_;

--- a/lib/HTTP/Headers/ETag.pm
+++ b/lib/HTTP/Headers/ETag.pm
@@ -8,48 +8,46 @@ our $VERSION = '7.01';
 require HTTP::Date;
 
 require HTTP::Headers;
-package
-    HTTP::Headers;
+package HTTP::Headers;
 
-sub _etags
-{
-    my $self = shift;
+sub _etags {
+    my $self   = shift;
     my $header = shift;
-    my @old = _split_etag_list($self->_header($header));
+    my @old    = _split_etag_list( $self->_header($header) );
     if (@_) {
-	$self->_header($header => join(", ", _split_etag_list(@_)));
+        $self->_header( $header => join( ", ", _split_etag_list(@_) ) );
     }
-    wantarray ? @old : join(", ", @old);
+    wantarray ? @old : join( ", ", @old );
 }
 
-sub etag          { shift->_etags("ETag", @_); }
-sub if_match      { shift->_etags("If-Match", @_); }
-sub if_none_match { shift->_etags("If-None-Match", @_); }
+sub etag          { shift->_etags( "ETag",          @_ ); }
+sub if_match      { shift->_etags( "If-Match",      @_ ); }
+sub if_none_match { shift->_etags( "If-None-Match", @_ ); }
 
 sub if_range {
+
     # Either a date or an entity-tag
     my $self = shift;
-    my @old = $self->_header("If-Range");
+    my @old  = $self->_header("If-Range");
     if (@_) {
-	my $new = shift;
-	if (!defined $new) {
-	    $self->remove_header("If-Range");
-	}
-	elsif ($new =~ /^\d+$/) {
-	    $self->_date_header("If-Range", $new);
-	}
-	else {
-	    $self->_etags("If-Range", $new);
-	}
+        my $new = shift;
+        if ( !defined $new ) {
+            $self->remove_header("If-Range");
+        }
+        elsif ( $new =~ /^\d+$/ ) {
+            $self->_date_header( "If-Range", $new );
+        }
+        else {
+            $self->_etags( "If-Range", $new );
+        }
     }
     return unless defined(wantarray);
     for (@old) {
-	my $t = HTTP::Date::str2time($_);
-	$_ = $t if $t;
+        my $t = HTTP::Date::str2time($_);
+        $_ = $t if $t;
     }
-    wantarray ? @old : join(", ", @old);
+    wantarray ? @old : join( ", ", @old );
 }
-
 
 # Split a list of entity tag values.  The return value is a list
 # consisting of one element per entity tag.  Suitable for parsing
@@ -61,36 +59,34 @@ sub if_range {
 #  weak		  = "W/"
 #  opaque-tag	  = quoted-string
 
-
-sub _split_etag_list
-{
-    my(@val) = @_;
+sub _split_etag_list {
+    my (@val) = @_;
     my @res;
     for (@val) {
         while (length) {
             my $weak = "";
-	    $weak = "W/" if s,^\s*[wW]/,,;
+            $weak = "W/" if s,^\s*[wW]/,,;
             my $etag = "";
-	    if (s/^\s*(\"[^\"\\]*(?:\\.[^\"\\]*)*\")//) {
-		push(@res, "$weak$1");
+            if (s/^\s*(\"[^\"\\]*(?:\\.[^\"\\]*)*\")//) {
+                push( @res, "$weak$1" );
             }
             elsif (s/^\s*,//) {
-                push(@res, qq(W/"")) if $weak;
+                push( @res, qq(W/"") ) if $weak;
             }
             elsif (s/^\s*([^,\s]+)//) {
                 $etag = $1;
-		$etag =~ s/([\"\\])/\\$1/g;
-	        push(@res, qq($weak"$etag"));
+                $etag =~ s/([\"\\])/\\$1/g;
+                push( @res, qq($weak"$etag") );
             }
-            elsif (s/^\s+// || !length) {
-                push(@res, qq(W/"")) if $weak;
+            elsif ( s/^\s+// || !length ) {
+                push( @res, qq(W/"") ) if $weak;
             }
             else {
-	 	die "This should not happen: '$_'";
+                die "This should not happen: '$_'";
             }
         }
-   }
-   @res;
+    }
+    @res;
 }
 
 1;

--- a/lib/HTTP/Headers/Util.pm
+++ b/lib/HTTP/Headers/Util.pm
@@ -7,89 +7,90 @@ our $VERSION = '7.01';
 
 use Exporter 5.57 'import';
 
-our @EXPORT_OK=qw(split_header_words _split_header_words join_header_words);
-
+our @EXPORT_OK = qw(split_header_words _split_header_words join_header_words);
 
 sub split_header_words {
     my @res = &_split_header_words;
     for my $arr (@res) {
-	for (my $i = @$arr - 2; $i >= 0; $i -= 2) {
-	    $arr->[$i] = lc($arr->[$i]);
-	}
+        for ( my $i = @$arr - 2 ; $i >= 0 ; $i -= 2 ) {
+            $arr->[$i] = lc( $arr->[$i] );
+        }
     }
     return @res;
 }
 
-sub _split_header_words
-{
-    my(@val) = @_;
+sub _split_header_words {
+    my (@val) = @_;
     my @res;
     for (@val) {
-	my @cur;
-	while (length) {
-	    if (s/^\s*(=*[^\s=;,]+)//) {  # 'token' or parameter 'attribute'
-		push(@cur, $1);
-		# a quoted value
-		if (s/^\s*=\s*\"([^\"\\]*(?:\\.[^\"\\]*)*)\"//) {
-		    my $val = $1;
-		    $val =~ s/\\(.)/$1/g;
-		    push(@cur, $val);
-		# some unquoted value
-		}
-		elsif (s/^\s*=\s*([^;,\s]*)//) {
-		    my $val = $1;
-		    $val =~ s/\s+$//;
-		    push(@cur, $val);
-		# no value, a lone token
-		}
-		else {
-		    push(@cur, undef);
-		}
-	    }
-	    elsif (s/^\s*,//) {
-		push(@res, [@cur]) if @cur;
-		@cur = ();
-	    }
-	    elsif (s/^\s*;// || s/^\s+// || s/^=//) {
-		# continue
-	    }
-	    else {
-		die "This should not happen: '$_'";
-	    }
-	}
-	push(@res, \@cur) if @cur;
+        my @cur;
+        while (length) {
+            if (s/^\s*(=*[^\s=;,]+)//) {    # 'token' or parameter 'attribute'
+                push( @cur, $1 );
+
+                # a quoted value
+                if (s/^\s*=\s*\"([^\"\\]*(?:\\.[^\"\\]*)*)\"//) {
+                    my $val = $1;
+                    $val =~ s/\\(.)/$1/g;
+                    push( @cur, $val );
+
+                    # some unquoted value
+                }
+                elsif (s/^\s*=\s*([^;,\s]*)//) {
+                    my $val = $1;
+                    $val =~ s/\s+$//;
+                    push( @cur, $val );
+
+                    # no value, a lone token
+                }
+                else {
+                    push( @cur, undef );
+                }
+            }
+            elsif (s/^\s*,//) {
+                push( @res, [@cur] ) if @cur;
+                @cur = ();
+            }
+            elsif ( s/^\s*;// || s/^\s+// || s/^=// ) {
+
+                # continue
+            }
+            else {
+                die "This should not happen: '$_'";
+            }
+        }
+        push( @res, \@cur ) if @cur;
     }
     @res;
 }
 
-
-sub join_header_words
-{
-    @_ = ([@_]) if @_ && !ref($_[0]);
+sub join_header_words {
+    @_ = ( [@_] ) if @_ && !ref( $_[0] );
     my @res;
     for (@_) {
-	my @cur = @$_;
-	my @attr;
-	while (@cur) {
-	    my $k = shift @cur;
-	    my $v = shift @cur;
-	    if (defined $v) {
-		if ($v =~ /[\x00-\x20()<>@,;:\\\"\/\[\]?={}\x7F-\xFF]/ || !length($v)) {
-		    $v =~ s/([\"\\])/\\$1/g;  # escape " and \
-		    $k .= qq(="$v");
-		}
-		else {
-		    # token
-		    $k .= "=$v";
-		}
-	    }
-	    push(@attr, $k);
-	}
-	push(@res, join("; ", @attr)) if @attr;
+        my @cur = @$_;
+        my @attr;
+        while (@cur) {
+            my $k = shift @cur;
+            my $v = shift @cur;
+            if ( defined $v ) {
+                if ( $v =~ /[\x00-\x20()<>@,;:\\\"\/\[\]?={}\x7F-\xFF]/
+                    || !length($v) )
+                {
+                    $v =~ s/([\"\\])/\\$1/g;    # escape " and \
+                    $k .= qq(="$v");
+                }
+                else {
+                    # token
+                    $k .= "=$v";
+                }
+            }
+            push( @attr, $k );
+        }
+        push( @res, join( "; ", @attr ) ) if @attr;
     }
-    join(", ", @res);
+    join( ", ", @res );
 }
-
 
 1;
 

--- a/t/common-req.t
+++ b/t/common-req.t
@@ -10,103 +10,102 @@ use HTTP::Request::Common;
 my $r = GET 'http://www.sn.no/';
 note $r->as_string;
 
-is($r->method, "GET");
-is($r->uri, "http://www.sn.no/");
+is( $r->method, "GET" );
+is( $r->uri,    "http://www.sn.no/" );
 
 $r = HEAD "http://www.sn.no/",
-     If_Match => 'abc',
-     From => 'aas@sn.no';
+  If_Match => 'abc',
+  From     => 'aas@sn.no';
 note $r->as_string;
 
-is($r->method, "HEAD");
-ok($r->uri->eq("http://www.sn.no"));
+is( $r->method, "HEAD" );
+ok( $r->uri->eq("http://www.sn.no") );
 
-is($r->header('If-Match'), "abc");
-is($r->header("from"), "aas\@sn.no");
+is( $r->header('If-Match'), "abc" );
+is( $r->header("from"),     "aas\@sn.no" );
+
+$r = HEAD "http://www.sn.no/", Content => 'foo';
+is( $r->content, 'foo' );
 
 $r = HEAD "http://www.sn.no/",
-	Content => 'foo';
-is($r->content, 'foo');
+  Content          => 'foo',
+  'Content-Length' => 50;
+is( $r->content,        'foo' );
+is( $r->content_length, 50 );
 
-$r = HEAD "http://www.sn.no/",
-	Content => 'foo',
-	'Content-Length' => 50;
-is($r->content, 'foo');
-is($r->content_length, 50);
-
-$r = PUT "http://www.sn.no",
-     Content => 'foo';
+$r = PUT "http://www.sn.no", Content => 'foo';
 note $r->as_string, "\n";
 
-is($r->method, "PUT");
-is($r->uri->host, "www.sn.no");
+is( $r->method,    "PUT" );
+is( $r->uri->host, "www.sn.no" );
 
-ok(!defined($r->header("Content")));
+ok( !defined( $r->header("Content") ) );
 
-is(${$r->content_ref}, "foo");
-is($r->content, "foo");
-is($r->content_length, 3);
+is( ${ $r->content_ref }, "foo" );
+is( $r->content,          "foo" );
+is( $r->content_length,   3 );
 
-$r = PUT "http://www.sn.no",
-     { foo => "bar" };
-is($r->content, "foo=bar");
+$r = PUT "http://www.sn.no", { foo => "bar" };
+is( $r->content, "foo=bar" );
 
-$r = OPTIONS "http://www.sn.no",
-     Content => 'foo';
+$r = OPTIONS "http://www.sn.no", Content => 'foo';
 note $r->as_string, "\n";
 
-is($r->method, "OPTIONS");
-is($r->uri->host, "www.sn.no");
+is( $r->method,    "OPTIONS" );
+is( $r->uri->host, "www.sn.no" );
 
-ok(!defined($r->header("Content")));
+ok( !defined( $r->header("Content") ) );
 
-is(${$r->content_ref}, "foo");
-is($r->content, "foo");
-is($r->content_length, 3);
+is( ${ $r->content_ref }, "foo" );
+is( $r->content,          "foo" );
+is( $r->content_length,   3 );
 
-$r = OPTIONS "http://www.sn.no",
-     { foo => "bar" };
-is($r->content, "foo=bar");
+$r = OPTIONS "http://www.sn.no", { foo => "bar" };
+is( $r->content, "foo=bar" );
 
-$r = PATCH "http://www.sn.no",
-     { foo => "bar" };
-is($r->content, "foo=bar");
+$r = PATCH "http://www.sn.no", { foo => "bar" };
+is( $r->content, "foo=bar" );
 
 #--- Test POST requests ---
 
-$r = POST "http://www.sn.no", [foo => 'bar;baz',
-                               baz => [qw(a b c)],
-                               foo => 'zoo=&',
-                               "space " => " + ",
-			       "nl" => "a\nb\r\nc\n",
-                              ],
-                              bar => 'foo';
+$r = POST "http://www.sn.no",
+  [
+    foo      => 'bar;baz',
+    baz      => [qw(a b c)],
+    foo      => 'zoo=&',
+    "space " => " + ",
+    "nl"     => "a\nb\r\nc\n",
+  ],
+  bar => 'foo';
 note $r->as_string, "\n";
 
-is($r->method, "POST");
-is($r->content_type, "application/x-www-form-urlencoded");
-is($r->content_length, 77, 'content_length');
-is($r->header("bar"), "foo", 'bar is foo');
-is($r->content, 'foo=bar%3Bbaz&baz=a&baz=b&baz=c&foo=zoo%3D%26&space+=+%2B+&nl=a%0Ab%0D%0Ac%0A');
+is( $r->method,         "POST" );
+is( $r->content_type,   "application/x-www-form-urlencoded" );
+is( $r->content_length, 77,    'content_length' );
+is( $r->header("bar"),  "foo", 'bar is foo' );
+is( $r->content,
+'foo=bar%3Bbaz&baz=a&baz=b&baz=c&foo=zoo%3D%26&space+=+%2B+&nl=a%0Ab%0D%0Ac%0A'
+);
 
 $r = POST "http://example.com";
-is($r->content_length, 0);
-is($r->content, "");
+is( $r->content_length, 0 );
+is( $r->content,        "" );
 
 $r = POST "http://example.com", [];
-is($r->content_length, 0);
-is($r->content, "");
+is( $r->content_length, 0 );
+is( $r->content,        "" );
 
 $r = POST "mailto:gisle\@aas.no",
-     Subject => "Heisan",
-     Content_Type => "text/plain",
-     Content => "Howdy\n";
+  Subject      => "Heisan",
+  Content_Type => "text/plain",
+  Content      => "Howdy\n";
+
 #note $r->as_string;
 
-is($r->method, "POST");
-is($r->header("Subject"), "Heisan");
-is($r->content, "Howdy\n");
-is($r->content_type, "text/plain");
+is( $r->method,            "POST" );
+is( $r->header("Subject"), "Heisan" );
+is( $r->content,           "Howdy\n" );
+is( $r->content_type,      "text/plain" );
 
 {
     my @warnings;
@@ -118,123 +117,138 @@ is($r->content_type, "text/plain");
 #
 # POST for File upload
 #
-my (undef, $file) = tempfile();
-my $form_file = (File::Spec->splitpath($file))[-1];
-open(FILE, ">$file") or die "Can't create $file: $!";
+my ( undef, $file ) = tempfile();
+my $form_file = ( File::Spec->splitpath($file) )[-1];
+open( FILE, ">$file" ) or die "Can't create $file: $!";
 print FILE "foo\nbar\nbaz\n";
 close(FILE);
 
 $r = POST 'http://www.perl.org/survey.cgi',
-       Content_Type => 'form-data',
-       Content      => [ name  => 'Gisle Aas',
-                         email => 'gisle@aas.no',
-                         gender => 'm',
-                         born   => '1964',
-                         file   => [$file],
-                       ];
+  Content_Type => 'form-data',
+  Content      => [
+    name   => 'Gisle Aas',
+    email  => 'gisle@aas.no',
+    gender => 'm',
+    born   => '1964',
+    file   => [$file],
+  ];
+
 #note $r->as_string;
 
 unlink($file) or warn "Can't unlink $file: $!";
 
-is($r->method, "POST");
-is($r->uri->path, "/survey.cgi");
-is($r->content_type, "multipart/form-data");
-ok($r->header('Content_type') =~ /boundary="?([^"]+)"?/);
+is( $r->method,       "POST" );
+is( $r->uri->path,    "/survey.cgi" );
+is( $r->content_type, "multipart/form-data" );
+ok( $r->header('Content_type') =~ /boundary="?([^"]+)"?/ );
 my $boundary = $1;
 
 my $c = $r->content;
 $c =~ s/\r//g;
-my @c = split(/--\Q$boundary/, $c);
+my @c = split( /--\Q$boundary/, $c );
 note "$c[5]\n";
 
-is(@c, 7);
-like($c[6], qr/^--\n/);  # 5 parts + header & trailer
+is( @c, 7 );
+like( $c[6], qr/^--\n/ );    # 5 parts + header & trailer
 
-ok($c[2] =~ /^Content-Disposition:\s*form-data;\s*name="email"/m);
-ok($c[2] =~ /^gisle\@aas.no$/m);
+ok( $c[2] =~ /^Content-Disposition:\s*form-data;\s*name="email"/m );
+ok( $c[2] =~ /^gisle\@aas.no$/m );
 
-ok($c[5] =~ /^Content-Disposition:\s*form-data;\s*name="file";\s*filename="$form_file"/m);
-ok($c[5] =~ /^Content-Type:\s*text\/plain$/m);
-ok($c[5] =~ /^foo\nbar\nbaz/m);
-
-$r = POST 'http://www.perl.org/survey.cgi',
-      [ file => [ undef, "xxy\"", Content_type => "text/html", Content => "<h1>Hello, world!</h1>" ]],
-      Content_type => 'multipart/form-data';
-#note $r->as_string;
-
-ok($r->content =~ /^--\S+\015\012Content-Disposition:\s*form-data;\s*name="file";\s*filename="xxy\\"/m);
-ok($r->content =~ /^Content-Type: text\/html/m);
-ok($r->content =~ /^<h1>Hello, world/m);
+ok( $c[5] =~
+/^Content-Disposition:\s*form-data;\s*name="file";\s*filename="$form_file"/m
+);
+ok( $c[5] =~ /^Content-Type:\s*text\/plain$/m );
+ok( $c[5] =~ /^foo\nbar\nbaz/m );
 
 $r = POST 'http://www.perl.org/survey.cgi',
-      Content_type => 'multipart/form-data',
-      Content => [ file => [ undef, undef, Content => "foo"]];
+  [
+    file => [
+        undef, "xxy\"",
+        Content_type => "text/html",
+        Content      => "<h1>Hello, world!</h1>"
+    ]
+  ],
+  Content_type => 'multipart/form-data';
+
 #note $r->as_string;
 
-unlike($r->content, qr/filename=/);
+ok( $r->content =~
+/^--\S+\015\012Content-Disposition:\s*form-data;\s*name="file";\s*filename="xxy\\"/m
+);
+ok( $r->content =~ /^Content-Type: text\/html/m );
+ok( $r->content =~ /^<h1>Hello, world/m );
 
+$r = POST 'http://www.perl.org/survey.cgi',
+  Content_type => 'multipart/form-data',
+  Content      => [ file => [ undef, undef, Content => "foo" ] ];
+
+#note $r->as_string;
+
+unlike( $r->content, qr/filename=/ );
 
 # The POST routine can now also take a hash reference.
-my %hash = (foo => 42, bar => 24);
+my %hash = ( foo => 42, bar => 24 );
 $r = POST 'http://www.perl.org/survey.cgi', \%hash;
-#note $r->as_string, "\n";
-like($r->content, qr/foo=42/);
-like($r->content, qr/bar=24/);
-is($r->content_type, "application/x-www-form-urlencoded");
-is($r->content_length, 13);
 
+#note $r->as_string, "\n";
+like( $r->content, qr/foo=42/ );
+like( $r->content, qr/bar=24/ );
+is( $r->content_type,   "application/x-www-form-urlencoded" );
+is( $r->content_length, 13 );
 
 #
 # POST for File upload
 #
 use HTTP::Request::Common qw($DYNAMIC_FILE_UPLOAD);
 
-(undef, $file) = tempfile();
-open(FILE, ">$file") or die "Can't create $file: $!";
-for (1..1000) {
-   print FILE "a" .. "z";
+( undef, $file ) = tempfile();
+open( FILE, ">$file" ) or die "Can't create $file: $!";
+for ( 1 .. 1000 ) {
+    print FILE "a" .. "z";
 }
 close(FILE);
 
 $DYNAMIC_FILE_UPLOAD++;
 $r = POST 'http://www.perl.org/survey.cgi',
-       Content_Type => 'form-data',
-       Content      => [ name  => 'Gisle Aas',
-                         email => 'gisle@aas.no',
-                         gender => 'm',
-                         born   => '1964',
-                         file   => [$file],
-                       ];
+  Content_Type => 'form-data',
+  Content      => [
+    name   => 'Gisle Aas',
+    email  => 'gisle@aas.no',
+    gender => 'm',
+    born   => '1964',
+    file   => [$file],
+  ];
+
 #note $r->as_string, "\n";
 
-is($r->method, "POST");
-is($r->uri->path, "/survey.cgi");
-is($r->content_type, "multipart/form-data");
-ok($r->header('Content_type') =~ qr/boundary="?([^"]+)"?/);
+is( $r->method,       "POST" );
+is( $r->uri->path,    "/survey.cgi" );
+is( $r->content_type, "multipart/form-data" );
+ok( $r->header('Content_type') =~ qr/boundary="?([^"]+)"?/ );
 $boundary = $1;
-is(ref($r->content), "CODE");
+is( ref( $r->content ), "CODE" );
 
-cmp_ok(length($boundary), '>', 10);
+cmp_ok( length($boundary), '>', 10 );
 
 my $code = $r->content;
 my $chunk;
 my @chunks;
-while (defined($chunk = &$code) && length $chunk) {
-   push(@chunks, $chunk);
+while ( defined( $chunk = &$code ) && length $chunk ) {
+    push( @chunks, $chunk );
 }
 
 unlink($file) or warn "Can't unlink $file: $!";
 
-$_ = join("", @chunks);
+$_ = join( "", @chunks );
 
 #note int(@chunks), " chunks, total size is ", length($_), " bytes\n";
 
 # should be close to expected size and number of chunks
-cmp_ok(abs(@chunks - 6), '<', 3);
-cmp_ok(abs(length($_) - 26589), '<', 20);
+cmp_ok( abs( @chunks - 6 ),        '<', 3 );
+cmp_ok( abs( length($_) - 26589 ), '<', 20 );
 
 $r = POST 'http://www.example.com';
-is($r->as_string, <<EOT);
+is( $r->as_string, <<EOT);
 POST http://www.example.com
 Content-Length: 0
 Content-Type: application/x-www-form-urlencoded
@@ -242,7 +256,7 @@ Content-Type: application/x-www-form-urlencoded
 EOT
 
 $r = POST 'http://www.example.com', Content_Type => 'form-data', Content => [];
-is($r->as_string, <<EOT);
+is( $r->as_string, <<EOT);
 POST http://www.example.com
 Content-Length: 0
 Content-Type: multipart/form-data; boundary=none
@@ -250,8 +264,9 @@ Content-Type: multipart/form-data; boundary=none
 EOT
 
 $r = POST 'http://www.example.com', Content_Type => 'form-data';
+
 #note $r->as_string;
-is($r->as_string, <<EOT);
+is( $r->as_string, <<EOT);
 POST http://www.example.com
 Content-Length: 0
 Content-Type: multipart/form-data
@@ -259,18 +274,18 @@ Content-Type: multipart/form-data
 EOT
 
 $r = HTTP::Request::Common::DELETE 'http://www.example.com';
-is($r->method, "DELETE");
+is( $r->method, "DELETE" );
 
 $r = HTTP::Request::Common::PUT 'http://www.example.com',
-    'Content-Type' => 'application/octet-steam',
-    'Content' => 'foobarbaz',
-    'Content-Length' => 12;   # a slight lie
-is($r->header('Content-Length'), 9);
+  'Content-Type'   => 'application/octet-steam',
+  'Content'        => 'foobarbaz',
+  'Content-Length' => 12;                          # a slight lie
+is( $r->header('Content-Length'), 9 );
 
 $r = HTTP::Request::Common::PATCH 'http://www.example.com',
-    'Content-Type' => 'application/octet-steam',
-    'Content' => 'foobarbaz',
-    'Content-Length' => 12;   # a slight lie
-is($r->header('Content-Length'), 9);
+  'Content-Type'   => 'application/octet-steam',
+  'Content'        => 'foobarbaz',
+  'Content-Length' => 12;                          # a slight lie
+is( $r->header('Content-Length'), 9 );
 
 done_testing();

--- a/t/headers-auth.t
+++ b/t/headers-auth.t
@@ -9,40 +9,47 @@ use HTTP::Response;
 use HTTP::Headers::Auth;
 
 my $res = HTTP::Response->new(401);
-$res->push_header(WWW_Authenticate => qq(Foo realm="WallyWorld", foo=bar, Bar realm="WallyWorld2"));
-$res->push_header(WWW_Authenticate => qq(Basic Realm="WallyWorld", foo=bar, bar=baz));
+$res->push_header( WWW_Authenticate =>
+      qq(Foo realm="WallyWorld", foo=bar, Bar realm="WallyWorld2") );
+$res->push_header(
+    WWW_Authenticate => qq(Basic Realm="WallyWorld", foo=bar, bar=baz) );
 
 note $res->as_string;
 
 my %auth = $res->www_authenticate;
 
-is(keys(%auth), 3);
+is( keys(%auth), 3 );
 
-is($auth{basic}{realm}, "WallyWorld");
-is($auth{bar}{realm}, "WallyWorld2");
+is( $auth{basic}{realm}, "WallyWorld" );
+is( $auth{bar}{realm},   "WallyWorld2" );
 
 $a = $res->www_authenticate;
-is($a, 'Foo realm="WallyWorld", foo=bar, Bar realm="WallyWorld2", Basic Realm="WallyWorld", foo=bar, bar=baz');
+is( $a,
+'Foo realm="WallyWorld", foo=bar, Bar realm="WallyWorld2", Basic Realm="WallyWorld", foo=bar, bar=baz'
+);
 
 $res->www_authenticate("Basic realm=foo1");
 note $res->as_string;
 
-$res->www_authenticate(Basic => {realm => "foo2"});
+$res->www_authenticate( Basic => { realm => "foo2" } );
 note $res->as_string;
 
-$res->www_authenticate(Basic => [realm => "foo3", foo=>33],
-                       Digest => {nonce=>"bar", foo=>'foo'});
+$res->www_authenticate(
+    Basic  => [ realm => "foo3", foo => 33 ],
+    Digest => { nonce => "bar", foo => 'foo' }
+);
 note $res->as_string;
 
 my $string = $res->as_string;
 
-like($string, qr/WWW-Authenticate: Basic realm="foo3", foo=33/);
-like($string, qr/WWW-Authenticate: Digest (nonce=bar, foo=foo|foo=foo, nonce=bar)/);
+like( $string, qr/WWW-Authenticate: Basic realm="foo3", foo=33/ );
+like( $string,
+    qr/WWW-Authenticate: Digest (nonce=bar, foo=foo|foo=foo, nonce=bar)/ );
 
 $res = HTTP::Response->new(401);
 my @auth = $res->proxy_authenticate('foo');
-is_deeply(\@auth, []);
-@auth = $res->proxy_authenticate('foo', 'bar');
-is_deeply(\@auth, ['foo', {}]);
-@auth = $res->proxy_authenticate('foo', {'bar' => '_'});
-is_deeply(\@auth, ['foo', {}, 'bar', {}]);
+is_deeply( \@auth, [] );
+@auth = $res->proxy_authenticate( 'foo', 'bar' );
+is_deeply( \@auth, [ 'foo', {} ] );
+@auth = $res->proxy_authenticate( 'foo', { 'bar' => '_' } );
+is_deeply( \@auth, [ 'foo', {}, 'bar', {} ] );

--- a/t/headers-etag.t
+++ b/t/headers-etag.t
@@ -10,36 +10,36 @@ require HTTP::Headers::ETag;
 my $h = HTTP::Headers->new;
 
 $h->etag("tag1");
-is($h->etag, qq("tag1"));
+is( $h->etag, qq("tag1") );
 
 $h->etag("w/tag2");
-is($h->etag, qq(W/"tag2"));
+is( $h->etag, qq(W/"tag2") );
 
 $h->etag(" w/, weaktag");
-is($h->etag, qq(W/"", "weaktag"));
+is( $h->etag, qq(W/"", "weaktag") );
 my @list = $h->etag;
-is_deeply(\@list, ['W/""', '"weaktag"']);
+is_deeply( \@list, [ 'W/""', '"weaktag"' ] );
 
 $h->etag(" w/");
-is($h->etag, qq(W/""));
+is( $h->etag, qq(W/"") );
 
 $h->etag(" ");
-is($h->etag, "");
+is( $h->etag, "" );
 
-$h->if_match(qq(W/"foo", bar, baz), "bar");
+$h->if_match( qq(W/"foo", bar, baz), "bar" );
 $h->if_none_match(333);
 
 $h->if_range("tag3");
-is($h->if_range, qq("tag3"));
+is( $h->if_range, qq("tag3") );
 
 my $t = time;
 $h->if_range($t);
-is($h->if_range, $t);
+is( $h->if_range, $t );
 
 note $h->as_string;
 
 @list = $h->if_range;
-is($#list, 0);
-is($list[0], $t);
+is( $#list,   0 );
+is( $list[0], $t );
 $h->if_range(undef);
-is($h->if_range, '');
+is( $h->if_range, '' );

--- a/t/headers-util.t
+++ b/t/headers-util.t
@@ -7,42 +7,44 @@ use HTTP::Headers::Util qw(split_header_words join_header_words);
 
 my @s_tests = (
 
-   ["foo"                     => "foo"],
-   ["foo=bar"                 => "foo=bar"],
-   ["   foo   "               => "foo"],
-   ["foo="                    => 'foo=""'],
-   ["foo=bar bar=baz"         => "foo=bar; bar=baz"],
-   ["foo=bar;bar=baz"         => "foo=bar; bar=baz"],
-   ['foo bar baz'             => "foo; bar; baz"],
-   ['foo="\"" bar="\\\\"'     => 'foo="\""; bar="\\\\"'],
-   ['foo,,,bar'               => 'foo, bar'],
-   ['foo=bar,bar=baz'         => 'foo=bar, bar=baz'],
+    [ "foo"                 => "foo" ],
+    [ "foo=bar"             => "foo=bar" ],
+    [ "   foo   "           => "foo" ],
+    [ "foo="                => 'foo=""' ],
+    [ "foo=bar bar=baz"     => "foo=bar; bar=baz" ],
+    [ "foo=bar;bar=baz"     => "foo=bar; bar=baz" ],
+    [ 'foo bar baz'         => "foo; bar; baz" ],
+    [ 'foo="\"" bar="\\\\"' => 'foo="\""; bar="\\\\"' ],
+    [ 'foo,,,bar'           => 'foo, bar' ],
+    [ 'foo=bar,bar=baz'     => 'foo=bar, bar=baz' ],
 
-   ['TEXT/HTML; CHARSET=ISO-8859-1' =>
-    'text/html; charset=ISO-8859-1'],
+    [ 'TEXT/HTML; CHARSET=ISO-8859-1' => 'text/html; charset=ISO-8859-1' ],
 
-   ['foo="bar"; port="80,81"; discard, bar=baz' =>
-    'foo=bar; port="80,81"; discard, bar=baz'],
+    [
+        'foo="bar"; port="80,81"; discard, bar=baz' =>
+          'foo=bar; port="80,81"; discard, bar=baz'
+    ],
 
-   ['Basic realm="\"foo\\\\bar\""' =>
-    'basic; realm="\"foo\\\\bar\""'],
+    [ 'Basic realm="\"foo\\\\bar\""' => 'basic; realm="\"foo\\\\bar\""' ],
 );
 
 plan tests => @s_tests + 4;
 
 for (@s_tests) {
-   my($arg, $expect) = @$_;
-   my @arg = ref($arg) ? @$arg : $arg;
+    my ( $arg, $expect ) = @$_;
+    my @arg = ref($arg) ? @$arg : $arg;
 
-   my $res = join_header_words(split_header_words(@arg));
-   is($res, $expect);
+    my $res = join_header_words( split_header_words(@arg) );
+    is( $res, $expect );
 }
 
-
 note "# Extra tests\n";
+
 # some extra tests
-is(join_header_words("foo" => undef, "bar" => "baz"), "foo; bar=baz");
-is(join_header_words(), "");
-is(join_header_words([]), "");
+is( join_header_words( "foo" => undef, "bar" => "baz" ), "foo; bar=baz" );
+is( join_header_words(),                                 "" );
+is( join_header_words( [] ),                             "" );
+
 # ignore bare =
-is_deeply(split_header_words("foo; =;bar=baz"), ["foo" => undef, "bar" => "baz"]);
+is_deeply( split_header_words("foo; =;bar=baz"),
+    [ "foo" => undef, "bar" => "baz" ] );

--- a/t/lib/Secret.pm
+++ b/t/lib/Secret.pm
@@ -10,7 +10,7 @@ use overload (
 
 sub new {
     my ( $class, $s ) = @_;
-    return bless sub {$s}, $class;
+    return bless sub { $s }, $class;
 }
 
 sub to_string { shift->(); }

--- a/t/message-charset.t
+++ b/t/message-charset.t
@@ -5,120 +5,120 @@ use Test::More;
 plan tests => 43;
 
 use HTTP::Response;
-my $r = HTTP::Response->new(200, "OK");
-is($r->content_charset, undef);
-is($r->content_type_charset, undef);
+my $r = HTTP::Response->new( 200, "OK" );
+is( $r->content_charset,      undef );
+is( $r->content_type_charset, undef );
 
 $r->content_type("text/plain");
-is($r->content_charset, undef);
+is( $r->content_charset, undef );
 
 $r->content("abc");
-is($r->content_charset, "US-ASCII");
+is( $r->content_charset, "US-ASCII" );
 
 $r->content("f\xE5rep\xF8lse\n");
-is($r->content_charset, "ISO-8859-1");
+is( $r->content_charset, "ISO-8859-1" );
 
 $r->content("f\xC3\xA5rep\xC3\xB8lse\n");
-is($r->content_charset, "UTF-8");
+is( $r->content_charset, "UTF-8" );
 
 $r->content_type("text/html");
 $r->content(<<'EOT');
 <meta charset="UTF-8">
 EOT
-is($r->content_charset, "UTF-8");
+is( $r->content_charset, "UTF-8" );
 
 $r->content(<<'EOT');
 <body>
 <META CharSet="Utf-16-LE">
 <meta charset="ISO-8859-1">
 EOT
-is($r->content_charset, "UTF-8");
+is( $r->content_charset, "UTF-8" );
 
 $r->content(<<'EOT');
 <!-- <meta charset="UTF-8">
 EOT
-is($r->content_charset, "US-ASCII");
+is( $r->content_charset, "US-ASCII" );
 
 $r->content(<<'EOT');
 <meta content="text/plain; charset=UTF-8">
 EOT
-is($r->content_charset, "UTF-8");
+is( $r->content_charset, "UTF-8" );
 
 $r->content_type('text/plain; charset="iso-8859-1"');
-is($r->content_charset, "ISO-8859-1");
-is($r->content_type_charset, "ISO-8859-1");
+is( $r->content_charset,      "ISO-8859-1" );
+is( $r->content_type_charset, "ISO-8859-1" );
 
 $r->content_type("application/xml");
 $r->content("<foo>..</foo>");
-is($r->content_charset, "UTF-8");
+is( $r->content_charset, "UTF-8" );
 
 require Encode;
-for my $enc ("UTF-16BE", "UTF-16LE", "UTF-32BE", "UTF-32LE") {
-    $r->content(Encode::encode($enc, "<foo>..</foo>"));
-    is($r->content_charset, $enc);
+for my $enc ( "UTF-16BE", "UTF-16LE", "UTF-32BE", "UTF-32LE" ) {
+    $r->content( Encode::encode( $enc, "<foo>..</foo>" ) );
+    is( $r->content_charset, $enc );
 }
 
 $r->content(<<'EOT');
 <?xml version="1.0" encoding="utf8" ?>
 EOT
-is($r->content_charset, "utf8");
+is( $r->content_charset, "utf8" );
 
 $r->content(<<'EOT');
 <?xml version="1.0" encoding=" "?>
 EOT
-is($r->content_charset, "UTF-8");
+is( $r->content_charset, "UTF-8" );
 
 $r->content(<<'EOT');
 <?xml version="1.0" encoding="  ISO-8859-1 "?>
 EOT
-is($r->content_charset, "ISO-8859-1");
+is( $r->content_charset, "ISO-8859-1" );
 
 $r->content(<<'EOT');
 <?xml version="1.0"
 encoding="US-ASCII" ?>
 EOT
-is($r->content_charset, "US-ASCII");
+is( $r->content_charset, "US-ASCII" );
 
 $r->content_type("application/json");
-for my $enc ("UTF-8", "UTF-16BE", "UTF-16LE", "UTF-32BE", "UTF-32LE") {
-    $r->content(Encode::encode($enc, "{}"));
-    is($r->content_charset, $enc);
+for my $enc ( "UTF-8", "UTF-16BE", "UTF-16LE", "UTF-32BE", "UTF-32LE" ) {
+    $r->content( Encode::encode( $enc, "{}" ) );
+    is( $r->content_charset, $enc );
 }
 
 {
- sub TIESCALAR{bless[]}
- tie $_, "";
- my $fail = 0;
- sub STORE{ ++$fail }
- sub FETCH{}
- $r->content_charset;
- is($fail, 0, 'content_charset leaves $_ alone');
+    sub TIESCALAR { bless [] }
+    tie $_, "";
+    my $fail = 0;
+    sub STORE { ++$fail }
+    sub FETCH { }
+    $r->content_charset;
+    is( $fail, 0, 'content_charset leaves $_ alone' );
 }
 
 $r->remove_content_headers;
 $r->content_type("text/plain; charset=UTF-8");
 $r->content("abc");
-is($r->decoded_content, "abc");
+is( $r->decoded_content, "abc" );
 
 $r->content("\xc3\xa5");
-is($r->decoded_content, chr(0xE5));
-is($r->decoded_content(charset => "none"), "\xC3\xA5");
-is($r->decoded_content(alt_charset => "UTF-8"), chr(0xE5));
-is($r->decoded_content(alt_charset => "none"), chr(0xE5));
+is( $r->decoded_content, chr(0xE5) );
+is( $r->decoded_content( charset     => "none" ),  "\xC3\xA5" );
+is( $r->decoded_content( alt_charset => "UTF-8" ), chr(0xE5) );
+is( $r->decoded_content( alt_charset => "none" ),  chr(0xE5) );
 
 $r->content_type("text/plain; charset=UTF");
-is($r->decoded_content, undef);
-is($r->decoded_content(charset => "UTF-8"), chr(0xE5));
-is($r->decoded_content(charset => "none"), "\xC3\xA5");
-is($r->decoded_content(alt_charset => "UTF-8"), chr(0xE5));
-is($r->decoded_content(alt_charset => "none"), "\xC3\xA5");
+is( $r->decoded_content, undef );
+is( $r->decoded_content( charset     => "UTF-8" ), chr(0xE5) );
+is( $r->decoded_content( charset     => "none" ),  "\xC3\xA5" );
+is( $r->decoded_content( alt_charset => "UTF-8" ), chr(0xE5) );
+is( $r->decoded_content( alt_charset => "none" ),  "\xC3\xA5" );
 
 # char semantics for latin-1?
-is($r->decoded_content(charset => "iso-8859-1"), "\xC3\xA5");
-is(lc($r->decoded_content(charset => "iso-8859-1")), "\xE3\xA5");
+is( $r->decoded_content( charset => "iso-8859-1" ),       "\xC3\xA5" );
+is( lc( $r->decoded_content( charset => "iso-8859-1" ) ), "\xE3\xA5" );
 
 $r->content_type("text/plain");
-is($r->decoded_content, chr(0xE5));
-is($r->decoded_content(charset => "none"), "\xC3\xA5");
-is($r->decoded_content(default_charset => "ISO-8859-1"), "\xC3\xA5");
-is($r->decoded_content(default_charset => "latin1"), "\xC3\xA5");
+is( $r->decoded_content, chr(0xE5) );
+is( $r->decoded_content( charset         => "none" ),       "\xC3\xA5" );
+is( $r->decoded_content( default_charset => "ISO-8859-1" ), "\xC3\xA5" );
+is( $r->decoded_content( default_charset => "latin1" ),     "\xC3\xA5" );

--- a/t/message-decode-brotlibomb.t
+++ b/t/message-decode-brotlibomb.t
@@ -5,58 +5,62 @@ use warnings;
 
 use Test::More;
 
-use HTTP::Headers    qw();
-use HTTP::Response   qw();
+use HTTP::Headers  qw();
+use HTTP::Response qw();
 
 use Test::Needs 'IO::Compress::Brotli', 'IO::Uncompress::Brotli';
 
 plan tests => 9;
 
 # Create a nasty brotli stream:
-my $size = 16 * 1024 * 1024;
+my $size   = 16 * 1024 * 1024;
 my $stream = "\0" x $size;
 
 # Compress that stream one time (since it won't compress it twice?!):
 my $compressed = $stream;
-my $bro = IO::Compress::Brotli->create;
+my $bro        = IO::Compress::Brotli->create;
 
-for( 1 ) {
+for (1) {
     my $last = $compressed;
-    $compressed = $bro->compress( $compressed );
+    $compressed = $bro->compress($compressed);
     $compressed .= $bro->finish();
     note sprintf "Encoded size %d bytes after round %d", length $compressed, $_;
-};
+}
 
 my $body = $compressed;
 
 my $headers = HTTP::Headers->new(
-    Content_Type => "application/xml",
-    Content_Encoding => 'br', # only one round needed for Brotli
+    Content_Type     => "application/xml",
+    Content_Encoding => 'br',                # only one round needed for Brotli
 );
-my $response = HTTP::Response->new(200, "OK", $headers, $body);
+my $response = HTTP::Response->new( 200, "OK", $headers, $body );
 
 my $len = length $response->decoded_content;
-is($len, 16 * 1024 * 1024, "Self-test: The decoded content length is 16M as expected" );
+is(
+    $len,
+    16 * 1024 * 1024,
+    "Self-test: The decoded content length is 16M as expected"
+);
 
 # Manual decompression check
 my $output = $compressed;
-for( 1 ) {
+for (1) {
     my $unbro = IO::Uncompress::Brotli->create();
     $output = $unbro->decompress($compressed);
-};
+}
 
 $headers = HTTP::Headers->new(
-    Content_Type => "application/xml",
-    Content_Encoding => 'br' # say my name, but only once
+    Content_Type     => "application/xml",
+    Content_Encoding => 'br'                 # say my name, but only once
 );
 
 $HTTP::Message::MAXIMUM_BODY_SIZE = 1024 * 1024;
 
-$response = HTTP::Response->new(200, "OK", $headers, $body);
-is $response->max_body_size, 1024*1024, "The default maximum body size holds";
+$response = HTTP::Response->new( 200, "OK", $headers, $body );
+is $response->max_body_size, 1024 * 1024, "The default maximum body size holds";
 
-$response->max_body_size( 512*1024 );
-is $response->max_body_size, 512*1024, "We can change the maximum body size";
+$response->max_body_size( 512 * 1024 );
+is $response->max_body_size, 512 * 1024, "We can change the maximum body size";
 
 my $content;
 my $lives = eval {
@@ -64,29 +68,36 @@ my $lives = eval {
     1;
 };
 my $err = $@;
-is $lives, undef, "We die when trying to decode something larger than our global limit of 512k"
-    or diag "... using IO::Uncompress::Brotli version $IO::Uncompress::Brotli::VERSION";
+is $lives, undef,
+  "We die when trying to decode something larger than our global limit of 512k"
+  or diag
+  "... using IO::Uncompress::Brotli version $IO::Uncompress::Brotli::VERSION";
 
 $response->max_body_size(undef);
-is $response->max_body_size, undef, "We can remove the maximum size restriction";
+is $response->max_body_size, undef,
+  "We can remove the maximum size restriction";
 $lives = eval {
     $content = $response->decoded_content( raise_error => 0 );
     1;
 };
-is $lives, 1, "We don't die when trying to decode something larger than our global limit of 1M";
-is length $content, 16 * 1024*1024, "We get the full content";
-is $content, $stream, "We really get the full content";
+is $lives, 1,
+"We don't die when trying to decode something larger than our global limit of 1M";
+is length $content, 16 * 1024 * 1024, "We get the full content";
+is $content,        $stream,          "We really get the full content";
 
 # The best usage of ->decoded_content:
 $lives = eval {
     $content = $response->decoded_content(
-        raise_error => 1,
-        max_body_size => 512 * 1024 );
+        raise_error   => 1,
+        max_body_size => 512 * 1024
+    );
     1;
 };
 $err = $@;
-is $lives, undef, "We die when trying to decode something larger than our limit of 512k using a parameter"
-    or diag "... using IO::Uncompress::Brotli version $IO::Uncompress::Brotli::VERSION";
+is $lives, undef,
+"We die when trying to decode something larger than our limit of 512k using a parameter"
+  or diag
+  "... using IO::Uncompress::Brotli version $IO::Uncompress::Brotli::VERSION";
 
 =head1 SEE ALSO
 

--- a/t/message-decode-bzipbomb.t
+++ b/t/message-decode-bzipbomb.t
@@ -6,63 +6,70 @@ use warnings;
 use Test::More;
 plan tests => 10;
 
-use HTTP::Headers    qw( );
-use HTTP::Response   qw( );
+use HTTP::Headers  qw( );
+use HTTP::Response qw( );
 
 # Create a nasty bzip2 stream:
-my $size = 16 * 1024 * 1024;
+my $size   = 16 * 1024 * 1024;
 my $stream = "\0" x $size;
 
 # Compress that stream three times:
 my $compressed = $stream;
-for( 1..3 ) {
+for ( 1 .. 3 ) {
     require IO::Compress::Bzip2;
     my $last = $compressed;
-    IO::Compress::Bzip2::bzip2(\$last, \$compressed)
-        or die "Can't bzip2 content: $IO::Compress::Bzip2::Bzip2Error";
-    #diag sprintf "Encoded size %d bytes after round %d", length $compressed, $_;
-};
+    IO::Compress::Bzip2::bzip2( \$last, \$compressed )
+      or die "Can't bzip2 content: $IO::Compress::Bzip2::Bzip2Error";
+
+   #diag sprintf "Encoded size %d bytes after round %d", length $compressed, $_;
+}
 
 my $body = $compressed;
 
 my $headers = HTTP::Headers->new(
-    Content_Type => "application/xml",
-    Content_Encoding => 'bzip2,bzip2,bzip2', # say my name three times
+    Content_Type     => "application/xml",
+    Content_Encoding => 'bzip2,bzip2,bzip2',    # say my name three times
 );
-my $response = HTTP::Response->new(200, "OK", $headers, $body);
+my $response = HTTP::Response->new( 200, "OK", $headers, $body );
 
 my $len = length $response->decoded_content( raise_error => 1 );
-is($len, 16 * 1024 * 1024, "Self-test: The decoded content length is 16M as expected" );
+is(
+    $len,
+    16 * 1024 * 1024,
+    "Self-test: The decoded content length is 16M as expected"
+);
 
 # Manual decompression check
 my $output = $compressed;
-for( 1..3 ) {
+for ( 1 .. 3 ) {
     my $last = $output;
     require Compress::Raw::Bzip2;
-    my ($i, $status) = Compress::Raw::Bunzip2->new(
-        1, # appendInput
-        0, # consumeInput
-        0, # small
+    my ( $i, $status ) = Compress::Raw::Bunzip2->new(
+        1,    # appendInput
+        0,    # consumeInput
+        0,    # small
         1,
     );
-    $output = "\0" x (1024*1024);
+    $output = "\0" x ( 1024 * 1024 );
+
     # Will modify $last, but we made a copy above
     my $res = $i->bzinflate( \$last, \$output );
-};
-is length $output, 1024*1024, "We manually recreate the limited original stream";
+}
+is length $output, 1024 * 1024,
+  "We manually recreate the limited original stream";
 
 $headers = HTTP::Headers->new(
-    Content_Type => "application/xml",
-    Content_Encoding => 'bzip2,bzip2,bzip2', # say my name three times
+    Content_Type     => "application/xml",
+    Content_Encoding => 'bzip2,bzip2,bzip2',    # say my name three times
 );
 
 $HTTP::Message::MAXIMUM_BODY_SIZE = 1024 * 1024;
 
-$response = HTTP::Response->new(200, "OK", $headers, $body);
-is $response->max_body_size, 1024*1024, "The default maximum body size holds";
+$response = HTTP::Response->new( 200, "OK", $headers, $body );
+is $response->max_body_size, 1024 * 1024, "The default maximum body size holds";
 
-$response->max_body_size( 512*1024 );
-is $response->max_body_size, 512*1024, "We can change the maximum body size";
+$response->max_body_size( 512 * 1024 );
+is $response->max_body_size, 512 * 1024, "We can change the maximum body size";
 
 my $content;
 my $lives = eval {
@@ -70,27 +77,32 @@ my $lives = eval {
     1;
 };
 my $err = $@;
-is $lives, undef, "We die when trying to decode something larger than our limit of 512k";
+is $lives, undef,
+  "We die when trying to decode something larger than our limit of 512k";
 
 $response->max_body_size(undef);
-is $response->max_body_size, undef, "We can remove the maximum size restriction";
+is $response->max_body_size, undef,
+  "We can remove the maximum size restriction";
 $lives = eval {
     $content = $response->decoded_content( raise_error => 0 );
     1;
 };
-is $lives, 1, "We don't die when trying to decode something larger than our global limit of 1M";
-is length $content, 16 * 1024*1024, "We get the full content";
-is $content, $stream, "We really get the full content";
+is $lives, 1,
+"We don't die when trying to decode something larger than our global limit of 1M";
+is length $content, 16 * 1024 * 1024, "We get the full content";
+is $content,        $stream,          "We really get the full content";
 
 # The best usage of ->decoded_content:
 $lives = eval {
     $content = $response->decoded_content(
-        raise_error => 1,
-        max_body_size => 512 * 1024 );
+        raise_error   => 1,
+        max_body_size => 512 * 1024
+    );
     1;
 };
 $err = $@;
-is $lives, undef, "We die when trying to decode something larger than our limit of 512k";
+is $lives, undef,
+  "We die when trying to decode something larger than our limit of 512k";
 
 =head1 SEE ALSO
 

--- a/t/message-decode-xml.t
+++ b/t/message-decode-xml.t
@@ -20,14 +20,14 @@ use PerlIO::encoding qw( );
 }
 
 for my $enc (qw( UTF-8 UTF-16le )) {
-    my $file = encode($enc,
-	($enc =~ /^UTF-/ ? "\x{FEFF}" : "") .
-	qq{<?xml version="1.0" encoding="$enc"?>\n} .
-	qq{<root>\x{C9}ric</root>\n}
-    );
+    my $file = encode( $enc,
+            ( $enc =~ /^UTF-/ ? "\x{FEFF}" : "" )
+          . qq{<?xml version="1.0" encoding="$enc"?>\n}
+          . qq{<root>\x{C9}ric</root>\n} );
 
-    my $headers = HTTP::Headers->new(Content_Type => "application/xml");
-    my $response = HTTP::Response->new(200, "OK", $headers, $file);
+    my $headers  = HTTP::Headers->new( Content_Type => "application/xml" );
+    my $response = HTTP::Response->new( 200, "OK", $headers, $file );
 
-    is($response->decoded_content, qq(<?xml version="1.0"?>\n<root>\x{c9}ric</root>\n), $enc);
+    is( $response->decoded_content,
+        qq(<?xml version="1.0"?>\n<root>\x{c9}ric</root>\n), $enc );
 }

--- a/t/message-decode-zipbomb.t
+++ b/t/message-decode-zipbomb.t
@@ -5,66 +5,72 @@ use warnings;
 
 use Test::More;
 
-use HTTP::Headers    qw( );
-use HTTP::Response   qw( );
+use HTTP::Headers  qw( );
+use HTTP::Response qw( );
 
 use Test::Needs { 'Compress::Raw::Zlib' => '2.062' };
 plan tests => 9;
 
 # Create a nasty gzip stream:
-my $size = 16 * 1024 * 1024;
+my $size   = 16 * 1024 * 1024;
 my $stream = "\0" x $size;
 
 # Compress that stream three times:
 my $compressed = $stream;
-for( 1..3 ) {
+for ( 1 .. 3 ) {
     require IO::Compress::Gzip;
     my $last = $compressed;
-    IO::Compress::Gzip::gzip(\$last, \$compressed, Level => 9, -Minimal => 1)
-        or die "Can't gzip content: $IO::Compress::Gzip::GzipError";
-    #diag sprintf "Encoded size %d bytes after round %d", length $compressed, $_;
-};
+    IO::Compress::Gzip::gzip( \$last, \$compressed, Level => 9, -Minimal => 1 )
+      or die "Can't gzip content: $IO::Compress::Gzip::GzipError";
+
+   #diag sprintf "Encoded size %d bytes after round %d", length $compressed, $_;
+}
 
 my $body = $compressed;
 
 my $headers = HTTP::Headers->new(
-    Content_Type => "application/xml",
-    Content_Encoding => 'gzip,gzip,gzip', # say my name three times
+    Content_Type     => "application/xml",
+    Content_Encoding => 'gzip,gzip,gzip',    # say my name three times
 );
-my $response = HTTP::Response->new(200, "OK", $headers, $body);
+my $response = HTTP::Response->new( 200, "OK", $headers, $body );
 
 my $len = length $response->decoded_content;
-is($len, 16 * 1024 * 1024, "Self-test: The decoded content length is 16M as expected" );
+is(
+    $len,
+    16 * 1024 * 1024,
+    "Self-test: The decoded content length is 16M as expected"
+);
 
 # Manual decompression check
 my $output = $compressed;
-for( 1..3 ) {
+for ( 1 .. 3 ) {
     use Compress::Raw::Zlib 'WANT_GZIP_OR_ZLIB', 'Z_BUF_ERROR';
 
     my $last = $output;
     require Compress::Raw::Zlib;
-    my ($i, $status) = Compress::Raw::Zlib::Inflate->new(
-        Bufsize => 1024*1024,
+    my ( $i, $status ) = Compress::Raw::Zlib::Inflate->new(
+        Bufsize     => 1024 * 1024,
         LimitOutput => 1,
-        WindowBits => WANT_GZIP_OR_ZLIB
+        WindowBits  => WANT_GZIP_OR_ZLIB
     );
     $output = '';
+
     # Will modify $last, but we made a copy above
     my $res = $i->inflate( \$last, \$output );
-};
+}
 
 $headers = HTTP::Headers->new(
-    Content_Type => "application/xml",
-    Content_Encoding => 'gzip, gzip, gzip' # say my name three times
+    Content_Type     => "application/xml",
+    Content_Encoding => 'gzip, gzip, gzip'    # say my name three times
 );
 
 $HTTP::Message::MAXIMUM_BODY_SIZE = 1024 * 1024;
 
-$response = HTTP::Response->new(200, "OK", $headers, $body);
-is $response->max_body_size, 1024*1024, "The default maximum body size holds";
+$response = HTTP::Response->new( 200, "OK", $headers, $body );
+is $response->max_body_size, 1024 * 1024, "The default maximum body size holds";
 
-$response->max_body_size( 512*1024 );
-is $response->max_body_size, 512*1024, "We can change the maximum body size";
+$response->max_body_size( 512 * 1024 );
+is $response->max_body_size, 512 * 1024, "We can change the maximum body size";
 
 my $content;
 my $lives = eval {
@@ -72,29 +78,34 @@ my $lives = eval {
     1;
 };
 my $err = $@;
-is $lives, undef, "We die when trying to decode something larger than our global limit of 512k"
-    or diag "... using Compress::Raw::Zlib version $Compress::Raw::Zlib::VERSION";
+is $lives, undef,
+  "We die when trying to decode something larger than our global limit of 512k"
+  or diag "... using Compress::Raw::Zlib version $Compress::Raw::Zlib::VERSION";
 
 $response->max_body_size(undef);
-is $response->max_body_size, undef, "We can remove the maximum size restriction";
+is $response->max_body_size, undef,
+  "We can remove the maximum size restriction";
 $lives = eval {
     $content = $response->decoded_content( raise_error => 0 );
     1;
 };
-is $lives, 1, "We don't die when trying to decode something larger than our global limit of 1M";
-is length $content, 16 * 1024*1024, "We get the full content";
-is $content, $stream, "We really get the full content";
+is $lives, 1,
+"We don't die when trying to decode something larger than our global limit of 1M";
+is length $content, 16 * 1024 * 1024, "We get the full content";
+is $content,        $stream,          "We really get the full content";
 
 # The best usage of ->decoded_content:
 $lives = eval {
     $content = $response->decoded_content(
-        raise_error => 1,
-        max_body_size => 512 * 1024 );
+        raise_error   => 1,
+        max_body_size => 512 * 1024
+    );
     1;
 };
 $err = $@;
-is $lives, undef, "We die when trying to decode something larger than our limit of 512k using a parameter"
-    or diag "... using Compress::Raw::Zlib version $Compress::Raw::Zlib::VERSION";
+is $lives, undef,
+"We die when trying to decode something larger than our limit of 512k using a parameter"
+  or diag "... using Compress::Raw::Zlib version $Compress::Raw::Zlib::VERSION";
 
 =head1 SEE ALSO
 

--- a/t/message-old.t
+++ b/t/message-old.t
@@ -13,76 +13,81 @@ require HTTP::Request;
 require HTTP::Response;
 
 require Time::Local if $^O eq "MacOS";
-my $offset = ($^O eq "MacOS") ? Time::Local::timegm(0,0,0,1,0,1970) : 0;
+my $offset =
+  ( $^O eq "MacOS" ) ? Time::Local::timegm( 0, 0, 0, 1, 0, 1970 ) : 0;
 
-my $req = HTTP::Request->new(GET => "http://www.sn.no/");
+my $req = HTTP::Request->new( GET => "http://www.sn.no/" );
 $req->header(
-	"if-modified-since" => "Thu, 03 Feb 1994 00:00:00 GMT",
-	"mime-version"      => "1.0");
+    "if-modified-since" => "Thu, 03 Feb 1994 00:00:00 GMT",
+    "mime-version"      => "1.0"
+);
 
-ok($req->as_string =~ /^GET/m);
-is($req->header("MIME-Version"), "1.0");
-is($req->if_modified_since, ((760233600 + $offset) || 0));
+ok( $req->as_string =~ /^GET/m );
+is( $req->header("MIME-Version"), "1.0" );
+is( $req->if_modified_since,      ( ( 760233600 + $offset ) || 0 ) );
 
 $req->content("gisle");
 $req->add_content(" aas");
-$req->add_content(\ " old interface is depreciated");
-${$req->content_ref} =~ s/\s+is\s+depreciated//;
+$req->add_content( \ " old interface is depreciated" );
+${ $req->content_ref } =~ s/\s+is\s+depreciated//;
 
-is($req->content, "gisle aas old interface");
+is( $req->content, "gisle aas old interface" );
 
 my $time = time;
 $req->date($time);
 my $timestr = gmtime($time);
-my($month) = ($timestr =~ /^\S+\s+(\S+)/);  # extract month;
+my ($month) = ( $timestr =~ /^\S+\s+(\S+)/ );    # extract month;
+
 #print "These should represent the same time:\n\t", $req->header('Date'), "\n\t$timestr\n";
-like($req->header('Date'), qr/\Q$month/);
+like( $req->header('Date'), qr/\Q$month/ );
 
-$req->authorization_basic("gisle", "passwd");
-is($req->header("Authorization"), "Basic Z2lzbGU6cGFzc3dk");
+$req->authorization_basic( "gisle", "passwd" );
+is( $req->header("Authorization"), "Basic Z2lzbGU6cGFzc3dk" );
 
-my($user, $pass) = $req->authorization_basic;
-is($user, "gisle");
-is($pass, "passwd");
+my ( $user, $pass ) = $req->authorization_basic;
+is( $user, "gisle" );
+is( $pass, "passwd" );
 
 # Check the response
-my $res = HTTP::Response->new(200, "This message");
-ok($res->is_success);
+my $res = HTTP::Response->new( 200, "This message" );
+ok( $res->is_success );
 
 my $html = $res->error_as_HTML;
-ok($html =~ /<head>/i && $html =~ /This message/);
+ok( $html =~ /<head>/i && $html =~ /This message/ );
 
 $res->content_type("text/html;version=3.0");
 $res->content("<html>...</html>\n");
 
 my $res2 = $res->clone;
-is($res2->code, 200);
-is($res2->header("cOntent-TYPE"), "text/html;version=3.0");
-like($res2->content, qr/>\.\.\.</);
+is( $res2->code,                   200 );
+is( $res2->header("cOntent-TYPE"), "text/html;version=3.0" );
+like( $res2->content, qr/>\.\.\.</ );
 
 # Check the base method:
-$res = HTTP::Response->new(200, "This message");
-is($res->base, undef);
+$res = HTTP::Response->new( 200, "This message" );
+is( $res->base, undef );
 $res->request($req);
 $res->content_type("image/gif");
 
-is($res->base, "http://www.sn.no/");
-$res->header('Base', 'http://www.sn.no/xxx/');
-is($res->base, "http://www.sn.no/xxx/");
+is( $res->base, "http://www.sn.no/" );
+$res->header( 'Base', 'http://www.sn.no/xxx/' );
+is( $res->base, "http://www.sn.no/xxx/" );
 
 # Check the AUTLOAD delegate method with regular expressions
 "This string contains text/html" =~ /(\w+\/\w+)/;
 $res->content_type($1);
-is($res->content_type, "text/html");
+is( $res->content_type, "text/html" );
 
 # Check what happens when passed a new URI object
 require URI;
-$req = HTTP::Request->new(GET => URI->new("http://localhost"));
-is($req->uri, "http://localhost");
+$req = HTTP::Request->new( GET => URI->new("http://localhost") );
+is( $req->uri, "http://localhost" );
 
-$req = HTTP::Request->new(GET => "http://www.example.com",
-	                  [ Foo => 1, bar => 2 ], "FooBar\n");
-is($req->as_string, <<EOT);
+$req = HTTP::Request->new(
+    GET => "http://www.example.com",
+    [ Foo => 1, bar => 2 ], "FooBar\n"
+);
+is( $req->as_string, <<EOT);
 GET http://www.example.com
 Bar: 2
 Foo: 1
@@ -91,7 +96,7 @@ FooBar
 EOT
 
 $req->clear;
-is($req->as_string,  <<EOT);
+is( $req->as_string, <<EOT);
 GET http://www.example.com
 
 EOT

--- a/t/request_type_with_data.t
+++ b/t/request_type_with_data.t
@@ -7,16 +7,18 @@ use HTTP::Request::Common;
 # I'd use Test::Warnings here, but let's respect our downstream consumers and
 # not force that prereq on them
 my @warnings;
-$SIG{__WARN__} = sub { push @warnings, grep { length } @_ };
+$SIG{__WARN__} = sub {
+    push @warnings, grep { length } @_;
+};
 
 my $request = HTTP::Request::Common::request_type_with_data(
-    'POST' => 'https://localhost/',
+    'POST'         => 'https://localhost/',
     'content_type' => 'multipart/form-data; boundary=----1234',
-    'content' => [ a => 1, b => undef ],
+    'content'      => [ a => 1, b => undef ],
 );
 
-isa_ok($request, 'HTTP::Request');
-is(scalar(@warnings), 0, 'no warnings')
-    or diag('got warnings: ', explain(\@warnings));
+isa_ok( $request, 'HTTP::Request' );
+is( scalar(@warnings), 0, 'no warnings' )
+  or diag( 'got warnings: ', explain( \@warnings ) );
 
 done_testing;

--- a/t/response.t
+++ b/t/response.t
@@ -14,168 +14,172 @@ use HTTP::Response;
 # make sure we get no failures from undefined response values
 {
     my $req = HTTP::Response->new();
-    is($req->is_success(), undef, 'Empty res: is_success');
-    is($req->is_info(), undef, 'Empty res: is_info');
-    is($req->is_redirect(), undef, 'Empty res: is_redirect');
-    is($req->is_error(), undef, 'Empty res: is_error');
-    is($req->is_client_error(), undef, 'Empty res: is_client_error');
-    is($req->is_server_error(), undef, 'Empty res: is_server_error');
-    is($req->filename(), undef, 'Empty res: filename');
+    is( $req->is_success(),      undef, 'Empty res: is_success' );
+    is( $req->is_info(),         undef, 'Empty res: is_info' );
+    is( $req->is_redirect(),     undef, 'Empty res: is_redirect' );
+    is( $req->is_error(),        undef, 'Empty res: is_error' );
+    is( $req->is_client_error(), undef, 'Empty res: is_client_error' );
+    is( $req->is_server_error(), undef, 'Empty res: is_server_error' );
+    is( $req->filename(),        undef, 'Empty res: filename' );
 }
 
 my $time = time;
 
-my $req = HTTP::Request->new(GET => 'http://www.sn.no');
-$req->date($time - 30);
+my $req = HTTP::Request->new( GET => 'http://www.sn.no' );
+$req->date( $time - 30 );
 
-my $r = HTTP::Response->new(200, "OK");
-$r->client_date($time - 20);
-$r->date($time - 25);
-$r->last_modified($time - 5000000);
+my $r = HTTP::Response->new( 200, "OK" );
+$r->client_date( $time - 20 );
+$r->date( $time - 25 );
+$r->last_modified( $time - 5000000 );
 $r->request($req);
 
 #note $r->as_string;
 
 my $current_age = $r->current_age;
 
-ok($current_age >= 35  && $current_age <= 40);
+ok( $current_age >= 35 && $current_age <= 40 );
 
 my $freshness_lifetime = $r->freshness_lifetime;
-ok($freshness_lifetime >= 12 * 3600);
-is($r->freshness_lifetime(heuristic_expiry => 0), undef);
+ok( $freshness_lifetime >= 12 * 3600 );
+is( $r->freshness_lifetime( heuristic_expiry => 0 ), undef );
 
 my $is_fresh = $r->is_fresh;
 ok($is_fresh);
-is($r->is_fresh(heuristic_expiry => 0), undef);
+is( $r->is_fresh( heuristic_expiry => 0 ), undef );
 
 note "current_age        = $current_age";
 note "freshness_lifetime = $freshness_lifetime";
 note "response is ", "not " x !$is_fresh, "fresh";
 note "it will be fresh for ", $freshness_lifetime - $current_age,
-     " more seconds";
+  " more seconds";
 
 # OK, now we add an Expires header
 $r->expires($time);
 note "\n", $r->dump;
 
 $freshness_lifetime = $r->freshness_lifetime;
-is($freshness_lifetime, 25);
+is( $freshness_lifetime, 25 );
 $r->remove_header('expires');
 
 # Now we try the 'Age' header and the Cache-Control:
-$r->header('Age', 300);
-$r->push_header('Cache-Control', 'junk');
-$r->push_header(Cache_Control => 'max-age = 10');
+$r->header( 'Age', 300 );
+$r->push_header( 'Cache-Control', 'junk' );
+$r->push_header( Cache_Control => 'max-age = 10' );
 
 #note $r->as_string;
 
-$current_age = $r->current_age;
+$current_age        = $r->current_age;
 $freshness_lifetime = $r->freshness_lifetime;
 
 note "current_age        = $current_age";
 note "freshness_lifetime = $freshness_lifetime";
 
-ok($current_age >= 300);
-is($freshness_lifetime, 10);
+ok( $current_age >= 300 );
+is( $freshness_lifetime, 10 );
 
-ok($r->fresh_until);  # should return something
-ok($r->fresh_until(heuristic_expiry => 0));  # should return something
+ok( $r->fresh_until );                             # should return something
+ok( $r->fresh_until( heuristic_expiry => 0 ) );    # should return something
 
-my $r2 = HTTP::Response->parse($r->as_string( "\x0d\x0a"));
+my $r2 = HTTP::Response->parse( $r->as_string("\x0d\x0a") );
 is( $r2->message(), 'OK', 'message() returns as expected' );
 
 my @h = $r2->header('Cache-Control');
-is(@h, 2);
+is( @h, 2 );
 
 $r->remove_header("Cache-Control");
 
-ok($r->fresh_until);  # should still return something
-is($r->fresh_until(heuristic_expiry => 0), undef);
+ok( $r->fresh_until );    # should still return something
+is( $r->fresh_until( heuristic_expiry => 0 ), undef );
 
-is($r->redirects, 0);
+is( $r->redirects, 0 );
 $r->previous($r2);
-is($r->previous, $r2);
-is($r->redirects, 1);
+is( $r->previous,  $r2 );
+is( $r->redirects, 1 );
 
-$r2->previous($r->clone);
-is($r->redirects, 2);
-for ($r->redirects) {
-    ok($_->is_success);
+$r2->previous( $r->clone );
+is( $r->redirects, 2 );
+for ( $r->redirects ) {
+    ok( $_->is_success );
 }
 
-is($r->base, $r->request->uri);
-$r->push_header("Content-Location", "/1/A/a");
-is($r->base, $r->request->uri); # we no longer consider Content-Location
-$r->push_header("Content-Base", "/2/;a=/foo/bar");
-is($r->base, "http://www.sn.no/2/;a=/foo/bar");
-$r->push_header("Content-Base", "/3/");
-is($r->base, "http://www.sn.no/2/;a=/foo/bar");
+is( $r->base, $r->request->uri );
+$r->push_header( "Content-Location", "/1/A/a" );
+is( $r->base, $r->request->uri );    # we no longer consider Content-Location
+$r->push_header( "Content-Base", "/2/;a=/foo/bar" );
+is( $r->base, "http://www.sn.no/2/;a=/foo/bar" );
+$r->push_header( "Content-Base", "/3/" );
+is( $r->base, "http://www.sn.no/2/;a=/foo/bar" );
 
 {
-	my @warn;
-	local $SIG{__WARN__} = sub { push @warn, @_ };
-	local $^W = 0;
-	$r2 = HTTP::Response->parse( undef );
-	is($#warn, -1);
-	local $^W = 1;
-	$r2 = HTTP::Response->parse( undef );
-	is($#warn, 0);
-	like($warn[0], qr/Undefined argument to parse\(\)/);
+    my @warn;
+    local $SIG{__WARN__} = sub { push @warn, @_ };
+    local $^W = 0;
+    $r2 = HTTP::Response->parse(undef);
+    is( $#warn, -1 );
+    local $^W = 1;
+    $r2 = HTTP::Response->parse(undef);
+    is( $#warn, 0 );
+    like( $warn[0], qr/Undefined argument to parse\(\)/ );
 }
-is($r2->code, undef);
-is($r2->message, undef);
-is($r2->protocol, undef);
-is($r2->status_line, "000 Unknown code");
+is( $r2->code,        undef );
+is( $r2->message,     undef );
+is( $r2->protocol,    undef );
+is( $r2->status_line, "000 Unknown code" );
 $r2->protocol('HTTP/1.0');
-is($r2->as_string("\n"), "HTTP/1.0 000 Unknown code\n\n");
-is($r2->dump, "HTTP/1.0 000 Unknown code\n\n(no content)\n");
-is($r2->current_age, 0);
-is($r2->freshness_lifetime, 3600);
-is($r2->freshness_lifetime(h_default => 900), 900);
-is($r2->freshness_lifetime(h_min => 7200), 7200);
-is($r2->freshness_lifetime(time => time), 3600);
-$r2->last_modified(time - 900);
-is($r2->freshness_lifetime, 90);
-is($r2->freshness_lifetime(h_lastmod_fraction => 0.2), 180);
-is($r2->freshness_lifetime(h_min => 300), 300);
-$r2->last_modified(time - 1000000);
-is($r2->freshness_lifetime(h_max => 7200), 7200);
-is($r2->freshness_lifetime(heuristic_expiry => 0), undef);
-is($r2->freshness_lifetime(heuristic_expiry => 1), 86400);
-ok($r2->is_fresh(time => time));
-ok($r2->fresh_until(time => time + 10));
+is( $r2->as_string("\n"),    "HTTP/1.0 000 Unknown code\n\n" );
+is( $r2->dump,               "HTTP/1.0 000 Unknown code\n\n(no content)\n" );
+is( $r2->current_age,        0 );
+is( $r2->freshness_lifetime, 3600 );
+is( $r2->freshness_lifetime( h_default => 900 ), 900 );
+is( $r2->freshness_lifetime( h_min => 7200 ),    7200 );
+is( $r2->freshness_lifetime( time => time ),     3600 );
+$r2->last_modified( time - 900 );
+is( $r2->freshness_lifetime, 90 );
+is( $r2->freshness_lifetime( h_lastmod_fraction => 0.2 ), 180 );
+is( $r2->freshness_lifetime( h_min              => 300 ), 300 );
+$r2->last_modified( time - 1000000 );
+is( $r2->freshness_lifetime( h_max            => 7200 ), 7200 );
+is( $r2->freshness_lifetime( heuristic_expiry => 0 ),    undef );
+is( $r2->freshness_lifetime( heuristic_expiry => 1 ),    86400 );
+ok( $r2->is_fresh( time => time ) );
+ok( $r2->fresh_until( time => time + 10 ) );
 
 $r2->client_date(1);
-cmp_ok(abs(time - $r2->current_age), '<', 10); # Allow 10s for slow boxes
-is($r2->freshness_lifetime, 60);
+cmp_ok( abs( time - $r2->current_age ), '<', 10 );    # Allow 10s for slow boxes
+is( $r2->freshness_lifetime, 60 );
 $r2->date(time);
-$r2->header(Age => -1);
-cmp_ok(abs(time - $r2->current_age), '<', 10); # Allow 10s for slow boxes
-is($r2->freshness_lifetime, 86400);
+$r2->header( Age => -1 );
+cmp_ok( abs( time - $r2->current_age ), '<', 10 );    # Allow 10s for slow boxes
+is( $r2->freshness_lifetime, 86400 );
 $req = HTTP::Request->new;
 $r2->request($req);
-cmp_ok(abs(time - $r2->current_age), '<', 10); # Allow 10s for slow boxes
+cmp_ok( abs( time - $r2->current_age ), '<', 10 );    # Allow 10s for slow boxes
 $req->date(2);
 $r2->request($req);
-cmp_ok(abs(time - $r2->current_age), '<', 10); # Allow 10s for slow boxes
+cmp_ok( abs( time - $r2->current_age ), '<', 10 );    # Allow 10s for slow boxes
 
-$r2->header ('Content-Disposition' => "attachment; filename=foo.txt\n");
-is($r2->filename(), 'foo.txt');
-$r2->header ('Content-Disposition' => "attachment; filename=\n");
-is($r2->filename(), '');
-$r2->header ('Content-Disposition' => "attachment\n");
-is($r2->filename(), undef);
-$r2->header ('Content-Disposition' => "attachment; filename==?US-ASCII?B?Zm9vLnR4dA==?=\n");
-is($r2->filename(), 'foo.txt');
-$r2->header ('Content-Disposition' => "attachment; filename==?NOT-A-CHARSET?B?Zm9vLnR4dA==?=\n");
-is($r2->filename(), '=?NOT-A-CHARSET?B?Zm9vLnR4dA==?=');
-$r2->header ('Content-Disposition' => "attachment; filename==?US-ASCII?Z?Zm9vLnR4dA==?=\n");
-is($r2->filename(), '=?US-ASCII?Z?Zm9vLnR4dA==?=');
-$r2->header ('Content-Disposition' => "attachment; filename==?US-ASCII?Q?foo.txt?=\n");
-is($r2->filename(), 'foo.txt');
-$r2->remove_header ('Content-Disposition');
-$r2->header ('Content-Location' => '/tmp/baz.txt');
-is($r2->filename(), 'baz.txt');
-$r2->remove_header ('Content-Location');
+$r2->header( 'Content-Disposition' => "attachment; filename=foo.txt\n" );
+is( $r2->filename(), 'foo.txt' );
+$r2->header( 'Content-Disposition' => "attachment; filename=\n" );
+is( $r2->filename(), '' );
+$r2->header( 'Content-Disposition' => "attachment\n" );
+is( $r2->filename(), undef );
+$r2->header( 'Content-Disposition' =>
+      "attachment; filename==?US-ASCII?B?Zm9vLnR4dA==?=\n" );
+is( $r2->filename(), 'foo.txt' );
+$r2->header( 'Content-Disposition' =>
+      "attachment; filename==?NOT-A-CHARSET?B?Zm9vLnR4dA==?=\n" );
+is( $r2->filename(), '=?NOT-A-CHARSET?B?Zm9vLnR4dA==?=' );
+$r2->header( 'Content-Disposition' =>
+      "attachment; filename==?US-ASCII?Z?Zm9vLnR4dA==?=\n" );
+is( $r2->filename(), '=?US-ASCII?Z?Zm9vLnR4dA==?=' );
+$r2->header(
+    'Content-Disposition' => "attachment; filename==?US-ASCII?Q?foo.txt?=\n" );
+is( $r2->filename(), 'foo.txt' );
+$r2->remove_header('Content-Disposition');
+$r2->header( 'Content-Location' => '/tmp/baz.txt' );
+is( $r2->filename(), 'baz.txt' );
+$r2->remove_header('Content-Location');
 $req->uri('http://www.example.com/bar.txt');
-is($r2->filename(), 'bar.txt');
+is( $r2->filename(), 'bar.txt' );

--- a/t/status-old.t
+++ b/t/status-old.t
@@ -6,14 +6,14 @@ plan tests => 8;
 
 use HTTP::Status;
 
-is(RC_OK, 200);
+is( RC_OK, 200 );
 
-ok(is_info(RC_CONTINUE));
-ok(is_success(RC_ACCEPTED));
-ok(is_error(RC_BAD_REQUEST));
-ok(is_redirect(RC_MOVED_PERMANENTLY));
+ok( is_info(RC_CONTINUE) );
+ok( is_success(RC_ACCEPTED) );
+ok( is_error(RC_BAD_REQUEST) );
+ok( is_redirect(RC_MOVED_PERMANENTLY) );
 
-ok(!is_success(RC_NOT_FOUND));
+ok( !is_success(RC_NOT_FOUND) );
 
-is(status_message(0), undef);
-is(status_message(200), "OK");
+is( status_message(0),   undef );
+is( status_message(200), "OK" );

--- a/t/status.t
+++ b/t/status.t
@@ -3,66 +3,66 @@ use warnings;
 
 use Test::More;
 
-use HTTP::Status qw(:constants :is status_message status_constant_name status_codes);
+use HTTP::Status
+  qw(:constants :is status_message status_constant_name status_codes);
 
-is(HTTP_OK, 200);
+is( HTTP_OK, 200 );
 
-ok(is_info(HTTP_CONTINUE));
-ok(is_success(HTTP_ACCEPTED));
-ok(is_error(HTTP_BAD_REQUEST));
-ok(is_redirect(HTTP_MOVED_PERMANENTLY));
-ok(is_redirect(HTTP_PERMANENT_REDIRECT));
+ok( is_info(HTTP_CONTINUE) );
+ok( is_success(HTTP_ACCEPTED) );
+ok( is_error(HTTP_BAD_REQUEST) );
+ok( is_redirect(HTTP_MOVED_PERMANENTLY) );
+ok( is_redirect(HTTP_PERMANENT_REDIRECT) );
 
 # renamed status constants
-ok(is_error(HTTP_REQUEST_ENTITY_TOO_LARGE));
-ok(is_error(HTTP_PAYLOAD_TOO_LARGE));
-ok(is_error(HTTP_REQUEST_URI_TOO_LARGE));
-ok(is_error(HTTP_URI_TOO_LONG));
-ok(is_error(HTTP_REQUEST_RANGE_NOT_SATISFIABLE));
-ok(is_error(HTTP_RANGE_NOT_SATISFIABLE));
-ok(is_error(HTTP_NO_CODE));
-ok(is_error(HTTP_UNORDERED_COLLECTION));
-ok(is_error(HTTP_TOO_EARLY));
-ok(is_error(HTTP_UNPROCESSABLE_ENTITY));
-ok(is_error(HTTP_PAYLOAD_TOO_LARGE));
+ok( is_error(HTTP_REQUEST_ENTITY_TOO_LARGE) );
+ok( is_error(HTTP_PAYLOAD_TOO_LARGE) );
+ok( is_error(HTTP_REQUEST_URI_TOO_LARGE) );
+ok( is_error(HTTP_URI_TOO_LONG) );
+ok( is_error(HTTP_REQUEST_RANGE_NOT_SATISFIABLE) );
+ok( is_error(HTTP_RANGE_NOT_SATISFIABLE) );
+ok( is_error(HTTP_NO_CODE) );
+ok( is_error(HTTP_UNORDERED_COLLECTION) );
+ok( is_error(HTTP_TOO_EARLY) );
+ok( is_error(HTTP_UNPROCESSABLE_ENTITY) );
+ok( is_error(HTTP_PAYLOAD_TOO_LARGE) );
 
 # Have a sip and a great day
-ok(is_client_error(HTTP_I_AM_A_TEAPOT));
-ok(is_error(HTTP_I_AM_A_TEAPOT));
-is(status_message(418), "I'm a teapot");
+ok( is_client_error(HTTP_I_AM_A_TEAPOT) );
+ok( is_error(HTTP_I_AM_A_TEAPOT) );
+is( status_message(418), "I'm a teapot" );
 
-ok(!is_success(HTTP_NOT_FOUND));
+ok( !is_success(HTTP_NOT_FOUND) );
 
-is(status_message(  0), undef);
-is(status_message(200), "OK");
-is(status_message(404), "Not Found");
-is(status_message(999), undef);
+is( status_message(0),   undef );
+is( status_message(200), "OK" );
+is( status_message(404), "Not Found" );
+is( status_message(999), undef );
 
+ok( !is_info(HTTP_NOT_FOUND) );
+ok( !is_success(HTTP_NOT_FOUND) );
+ok( !is_redirect(HTTP_NOT_FOUND) );
+ok( !is_error(HTTP_CONTINUE) );
+ok( !is_client_error(HTTP_CONTINUE) );
+ok( !is_server_error(HTTP_NOT_FOUND) );
+ok( !is_server_error(999) );
+ok( !is_info(99) );
+ok( !is_success(99) );
+ok( !is_redirect(99) );
 
-ok(!is_info(HTTP_NOT_FOUND));
-ok(!is_success(HTTP_NOT_FOUND));
-ok(!is_redirect(HTTP_NOT_FOUND));
-ok(!is_error(HTTP_CONTINUE));
-ok(!is_client_error(HTTP_CONTINUE));
-ok(!is_server_error(HTTP_NOT_FOUND));
-ok(!is_server_error(999));
-ok(!is_info(99));
-ok(!is_success(99));
-ok(!is_redirect(99));
+ok( is_cacheable_by_default($_),
+    "Cacheable by default [$_] " . status_message($_) )
+  for ( 200, 203, 204, 206, 300, 301, 308, 404, 405, 410, 414, 451, 501 );
 
-ok(is_cacheable_by_default($_),
-  "Cacheable by default [$_] " . status_message($_)
-) for (200,203,204,206,300,301,308,404,405,410,414,451,501);
+ok( !is_cacheable_by_default($_),
+    "... is not cacheable [$_] " . status_message($_) )
+  for ( 100, 201, 302, 400, 500 );
 
-ok(!is_cacheable_by_default($_),
-  "... is not cacheable [$_] " . status_message($_)
-) for (100,201,302,400,500);
-
-is(status_constant_name(HTTP_OK), "HTTP_OK");
-is(status_constant_name(404),     "HTTP_NOT_FOUND");
-is(status_constant_name(999),     undef);
+is( status_constant_name(HTTP_OK), "HTTP_OK" );
+is( status_constant_name(404),     "HTTP_NOT_FOUND" );
+is( status_constant_name(999),     undef );
 
 my %status_codes = status_codes();
-is($status_codes{200}, status_message(200));
+is( $status_codes{200}, status_message(200) );
 
 done_testing;


### PR DESCRIPTION
Rework https://github.com/libwww-perl/HTTP-Message/pull/203.


d231eb5827ba2d292bdfa468ac646162c9e49ebf Fix small path correction in CONTRIBUTING.md.
52281123dcad9433f5061a7586fd69f0313427aa I applied perltidy to some .pm and .t that is not to affect with other open PRs.
bfa7cc03923b01650404ac95d736a613a34317b4 Also made some manual adjustments to tab characters in comments.


The difference from #203 is the modified files were narrowed down using the following command (with refspec added to remotes/pr/).

```
% comm -23 <(git ls-files | sort) <(echo -n "8,16,23,25,35,93,99,117,122,141" | xargs -d, -I% sh -c 'git diff --name-only master...remotes/pr/%/head' | sort | uniq) | grep -E -e 'lib/' -e 't/.*\.t$'
lib/HTTP/Headers/Auth.pm
lib/HTTP/Headers/ETag.pm
lib/HTTP/Headers/Util.pm
t/common-req.t
t/headers-auth.t
t/headers-etag.t
t/headers-util.t
t/lib/Secret.pm
t/message-brotli.t
t/message-charset.t
t/message-decode-brotlibomb.t
t/message-decode-bzipbomb.t
t/message-decode-xml.t
t/message-decode-zipbomb.t
t/message-old.t
t/request_type_with_data.t
t/response.t
t/status-old.t
t/status.t
```