### PR TITLE
properly support an HTTP method of '0'

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -74,6 +74,9 @@ jobs:
         with:
           name: build_dir
           path: .
+      - uses: perl-actions/setup-cpm@v1
+        with:
+          version: compat
       - name: Install deps
         if: success()
         run: >
@@ -120,18 +123,17 @@ jobs:
           name: build_dir
           path: .
       - run: perl -V
-      - name: install deps using cpanm
-        uses: perl-actions/install-with-cpm@v2
+      - uses: perl-actions/setup-cpm@v1
         with:
-          cpanfile: "cpanfile"
-          args: >
-            --with-develop
-            ${{ steps.with-recommends.outputs.flag }}
-            --with-suggests
-            --with-test
-            --mirror https://cpan.metacpan.org
-          # App::cpm v0.999.0+ requires Perl 5.24+; pin older Perls to the last compatible release.
-          version: ${{ matrix.perl-version <= '5.22' && '0.998003' || 'main' }}
+          version: compat
+      - name: install deps using cpanm
+        run: >
+          cpm install -g --cpanfile cpanfile
+          --with-develop
+          ${{ steps.with-recommends.outputs.flag }}
+          --with-suggests
+          --with-test
+          --mirror https://cpan.metacpan.org
       - run: prove -lr t
         env:
           AUTHOR_TESTING: 1
@@ -167,13 +169,11 @@ jobs:
         with:
           name: build_dir
           path: .
-      - name: install deps using cpanm
-        uses: perl-actions/install-with-cpm@v2
+      - uses: perl-actions/setup-cpm@v1
         with:
-          cpanfile: "cpanfile"
-          args: "--mirror https://cpan.metacpan.org"
-          # App::cpm v0.999.0+ requires Perl 5.24+; pin older Perls to the last compatible release.
-          version: ${{ matrix.perl-version <= '5.22' && '0.998003' || 'main' }}
+          version: compat
+      - name: install deps using cpanm
+        run: cpm install -g --cpanfile cpanfile --mirror https://cpan.metacpan.org
       - run: perl -V
       - run: prove -lr t
         env:

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for HTTP-Message
 
 {{$NEXT}}
+    - now handling HTTP method '0' (Karen Etheridge)
 
 7.01      2025-10-19 17:22:21Z
     - Fix HTTP::Response and HTTP::Request as_string/parse commutativity issue

--- a/lib/HTTP/Request.pm
+++ b/lib/HTTP/Request.pm
@@ -118,7 +118,8 @@ sub as_string
     my($eol) = @_;
     $eol = "\n" unless defined $eol;
 
-    my $req_line = $self->method || "-";
+    # method must be at least one char, matching ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
+    my $req_line = (length $self->method) ? $self->method : "-";
     my $uri = $self->uri;
     $uri = (defined $uri) ? $uri->as_string : "-";
     $req_line .= " $uri";
@@ -131,7 +132,7 @@ sub as_string
 sub dump
 {
     my $self = shift;
-    my @pre = ($self->method || "-", $self->uri || "-");
+    my @pre = ((length $self->method) ? $self->method : "-", (defined $self->uri) ? $self->uri : "-");
     if (my $prot = $self->protocol) {
 	push(@pre, $prot);
     }

--- a/lib/HTTP/Request.pm
+++ b/lib/HTTP/Request.pm
@@ -119,7 +119,7 @@ sub as_string
     $eol = "\n" unless defined $eol;
 
     # method must be at least one char, matching ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
-    my $req_line = (length $self->method) ? $self->method : "-";
+    my $req_line = (defined $self->method && length $self->method) ? $self->method : "-";
     my $uri = $self->uri;
     $uri = (defined $uri) ? $uri->as_string : "-";
     $req_line .= " $uri";
@@ -132,7 +132,7 @@ sub as_string
 sub dump
 {
     my $self = shift;
-    my @pre = ((length $self->method) ? $self->method : "-", (defined $self->uri) ? $self->uri : "-");
+    my @pre = ((defined $self->method && length $self->method) ? $self->method : "-", (defined $self->uri) ? $self->uri : "-");
     if (my $prot = $self->protocol) {
 	push(@pre, $prot);
     }

--- a/t/request.t
+++ b/t/request.t
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 use Test::More;
-plan tests => 39;
+plan tests => 43;
 
 use HTTP::Request;
 use Try::Tiny qw( catch try );
@@ -166,3 +166,13 @@ $r2 = HTTP::Request->parse('methonly http://www.example.com/');
 is( $r2->method,   'methonly' );
 is( $r2->uri,      'http://www.example.com/' );
 is( $r2->protocol, undef );
+
+my $r3 = HTTP::Request->new(0 => "0");
+is($r3->method, '0', '0 is a valid HTTP method');
+is($r3->uri, '0', '0 is a valid URI');
+is($r3->as_string, "0 0\n\n", 'parsed zero method, zero uri req');
+is($r3->dump, <<EOT, 'dumped zero method, zero uri req');
+0 0
+
+(no content)
+EOT


### PR DESCRIPTION
This is valid according to RFC9110: see
https://datatracker.ietf.org/doc/html/rfc9110#appendix-A for the full ABNF, which is equivalent to the regex: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$