### PR TITLE
Add informational HTTP::XSHeaders compatibility CI job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -89,6 +89,41 @@ jobs:
       - name: Run Tests
         if: success()
         run: prove -lr --jobs 2 t
+  test_xsheaders:
+    runs-on: ubuntu-latest
+    name: HTTP::XSHeaders compat (Perl 5.42)
+    needs: build
+    # Informational only: surfaces HTTP::XSHeaders API incompatibilities
+    # without blocking the build. See p5pclub/http-xsheaders#13.
+    continue-on-error: true
+    container:
+      image: perldocker/perl-tester:5.42
+      env:
+        AUTHOR_TESTING: 1
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: build_dir
+          path: .
+      - uses: perl-actions/setup-cpm@v1
+        with:
+          version: compat
+      - name: Install deps
+        run: >
+          cpm install -g
+          --cpanfile cpanfile
+          --with-develop
+          --with-recommends
+          --with-suggests
+          --show-build-log-on-failure
+      - name: Install HTTP::XSHeaders
+        run: cpm install -g --show-build-log-on-failure HTTP::XSHeaders
+      # Loading HTTP::XSHeaders transparently swaps in its C implementation of
+      # HTTP::Headers, so the existing suite exercises the XS code path.
+      - name: Run tests against HTTP::XSHeaders
+        env:
+          PERL5OPT: -MHTTP::XSHeaders
+        run: prove -lr --jobs 2 t
   test_macos:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/dist.ini
+++ b/dist.ini
@@ -9,6 +9,9 @@ copyright_year   = 1994
 x_IRC = irc://irc.perl.org/#lwp
 x_MailingList = mailto:libwww@perl.org
 
+[Prereqs / TestRequires]
+Test::Differences = 0
+
 [Prereqs]
 Compress::Raw::Zlib = 2.062
 Encode = 3.01

--- a/t/headers.t
+++ b/t/headers.t
@@ -5,6 +5,7 @@ use lib 't/lib';
 
 use Secret ();
 use Test::More;
+use Test::Differences;
 
 plan tests => 189;
 
@@ -93,7 +94,7 @@ $h = HTTP::Headers->new(
     user_agent => "libwww-perl",
     zoo => "foo",
    );
-is($h->as_string, <<EOT);
+eq_or_diff($h->as_string, <<EOT);
 Date: today
 User-Agent: libwww-perl
 ETag: abc
@@ -109,9 +110,9 @@ Zoo: foo
 EOT
 
 $h2 = $h->clone;
-is($h->as_string, $h2->as_string);
+eq_or_diff($h->as_string, $h2->as_string);
 
-is($h->remove_content_headers->as_string, <<EOT);
+eq_or_diff($h->remove_content_headers->as_string, <<EOT);
 Allow: GET
 Content-Encoding: gzip
 Content-MD5: dummy
@@ -121,7 +122,7 @@ Last-Modified: yesterday
 Content-Foo: bar
 EOT
 
-is($h->as_string, <<EOT);
+eq_or_diff($h->as_string, <<EOT);
 Date: today
 User-Agent: libwww-perl
 ETag: abc
@@ -131,7 +132,7 @@ EOT
 
 # separate code path for the void context case, so test it as well
 $h2->remove_content_headers;
-is($h->as_string, $h2->as_string);
+eq_or_diff($h->as_string, $h2->as_string);
 
 $h->clear;
 is($h->as_string, "");
@@ -257,7 +258,7 @@ is($h->referer, "http://www.example.com/");
     is($h->referrer->as_string, "http://www.example.com");
 }
 
-is($h->as_string, <<EOT);
+eq_or_diff($h->as_string, <<EOT);
 From: Gisle\@ActiveState.com
 Referer: http://www.example.com
 User-Agent: Mozilla/1.2
@@ -292,7 +293,7 @@ is($h->proxy_authorization_basic("u2", "p2"), undef);
 is(j($h->proxy_authorization_basic), "u2|p2");
 is($h->proxy_authorization, "Basic dTI6cDI=");
 
-is($h->as_string, <<EOT);
+eq_or_diff($h->as_string, <<EOT);
 Authorization: Basic dTpw
 Proxy-Authorization: Basic dTI6cDI=
 Proxy-Authenticate: bar
@@ -372,7 +373,7 @@ $h = HTTP::Headers->new(
 	e => "foo\n  bar  ",
 	f => "foo\n bar\n  baz\nbaz",
      );
-is($h->as_string("<<\n"), <<EOT);
+eq_or_diff($h->as_string("<<\n"), <<EOT);
 A: foo<<
 B: foo<<
  bar<<
@@ -394,7 +395,7 @@ $h = HTTP::Headers->new(
     b => "foo\015\012\015\012evil body" ,
     c => "foo\x0d\x0a\x0d\x0aevil body" ,
 );
-is (
+eq_or_diff (
     $h->as_string(),
     "A: foo\r\n evil body\n".
     "B: foo\015\012 evil body\n" .
@@ -431,7 +432,7 @@ $h->header(content_md5 => "dummy");
 $h->header("Content-Foo" => "foo");
 $h->header(Location => "http:", xyzzy => "plugh!");
 
-is($h->as_string, <<EOT);
+eq_or_diff($h->as_string, <<EOT);
 Location: http:
 Content-MD5: dummy
 Content-Type: text/plain
@@ -440,12 +441,12 @@ Xyzzy: plugh!
 EOT
 
 my $c = $h->remove_content_headers;
-is($h->as_string, <<EOT);
+eq_or_diff($h->as_string, <<EOT);
 Location: http:
 Xyzzy: plugh!
 EOT
 
-is($c->as_string, <<EOT);
+eq_or_diff($c->as_string, <<EOT);
 Content-MD5: dummy
 Content-Type: text/plain
 Content-Foo: foo
@@ -459,7 +460,7 @@ is(j($h->header_field_names), "Content-Type|:content_type|:foo_bar");
 is($h->header('Content-Type'), "text/plain");
 is($h->header(':Content_Type'), undef);
 is($h->header(':content_type'), "text/html");
-is($h->as_string, <<EOT);
+eq_or_diff($h->as_string, <<EOT);
 Content-Type: text/plain
 content_type: text/html
 foo_bar: 1
@@ -469,7 +470,7 @@ $h = HTTP::Headers->new;
 ok(!defined $h->warning('foo', 'INIT'));
 is($h->warning('bar'), 'foo');
 is($h->warning('baz', 'GET'), 'bar');
-is($h->as_string, <<EOT);
+eq_or_diff($h->as_string, <<EOT);
 Warning: bar
 EOT
 
@@ -482,7 +483,7 @@ is(j($h->header_field_names), ':foo|:zap');
 $h->scan(sub { $_[1] .= '!' });
 is(j($h->header(':zap')), 'bang!|kapow!|shazam!');
 is(j($h->header(':foo')), 'bar');
-is($h->as_string, <<EOT);
+eq_or_diff($h->as_string, <<EOT);
 foo: bar
 zap: bang!
 zap: kapow!


### PR DESCRIPTION
## Summary

Adds a `test_xsheaders` CI job that runs the existing `HTTP::Message` test suite against [`HTTP::XSHeaders`](https://metacpan.org/pod/HTTP::XSHeaders) to verify API compatibility, as requested in p5pclub/http-xsheaders#13.

- Pinned to a single recent Perl (5.42) as a fast compatibility canary.
- Installs `HTTP::XSHeaders`, then runs `prove -lr t` with `PERL5OPT=-MHTTP::XSHeaders`. Loading the module transparently swaps in its C implementation of `HTTP::Headers`, so the suite exercises the XS code path.
- Marked `continue-on-error: true` — **informational only**, so any incompatibilities surface in the logs without blocking the build.

## Notes

- The suite includes `headers-util.t`, but `HTTP::XSHeaders` only overrides `HTTP::Headers`/`HTTP::Headers::Fast` (not `HTTP::Headers::Util`), so those tests run against the pure-Perl util module as before.
- The real value is reading the job logs after the first run to see which (if any) assertions diverge under the XS implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)