### PR TITLE
Fix max_body_size for Content-Encoding: br

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for HTTP-Message
 
 {{$NEXT}}
+    - Fix max_body_size for Content-Encoding: br, which made every brotli
+      response fail to decode whenever a limit was set (GH#229)
 
 7.02      2026-06-05 23:28:36Z
     - now handling HTTP method '0' (GH#211) (Karen Etheridge)

--- a/lib/HTTP/Message.pm
+++ b/lib/HTTP/Message.pm
@@ -341,12 +341,23 @@ sub decoded_content
 		}
 		elsif ($ce eq 'br') {
 		    require IO::Uncompress::Brotli;
-		    my $bro = IO::Uncompress::Brotli->create;
 
 		    my $output;
 		    if( defined $content_limit ) {
-			$output = eval { $bro->decompress( $$content_ref, $content_limit ); }
+			# unbro() is the only brotli interface that takes a size
+			# limit; the streaming decompress() method cannot stop
+			# short. It decodes into a buffer of $content_limit
+			# octets, so the limit bounds the allocation directly.
+			$output = eval {
+			    IO::Uncompress::Brotli::unbro($$content_ref, $content_limit);
+			};
+			# Brotli reports "output buffer too small" and "this is
+			# not valid brotli" identically, so, unlike the gzip and
+			# bzip2 branches, we cannot say for certain which it was.
+			$@ and $@ =~ /BrotliDecoderDecompress/
+			    and Carp::croak("Can't unbrotli content: it is corrupt, or would decode to more than $content_limit octets");
 		    } else {
+			my $bro = IO::Uncompress::Brotli->create;
 			$output = eval { $bro->decompress($$content_ref) };
 		    }
 

--- a/t/message-decode-brotlibomb.t
+++ b/t/message-decode-brotlibomb.t
@@ -10,8 +10,6 @@ use HTTP::Response   qw();
 
 use Test::Needs 'IO::Compress::Brotli', 'IO::Uncompress::Brotli';
 
-plan tests => 9;
-
 # Create a nasty brotli stream:
 my $size = 16 * 1024 * 1024;
 my $stream = "\0" x $size;
@@ -66,6 +64,8 @@ my $lives = eval {
 my $err = $@;
 is $lives, undef, "We die when trying to decode something larger than our global limit of 512k"
     or diag "... using IO::Uncompress::Brotli version $IO::Uncompress::Brotli::VERSION";
+like( $err, qr/more than 524288 octets/,
+    '... and we die because of the limit, not for some other reason' );
 
 $response->max_body_size(undef);
 is $response->max_body_size, undef, "We can remove the maximum size restriction";
@@ -87,6 +87,29 @@ $lives = eval {
 $err = $@;
 is $lives, undef, "We die when trying to decode something larger than our limit of 512k using a parameter"
     or diag "... using IO::Uncompress::Brotli version $IO::Uncompress::Brotli::VERSION";
+
+# Setting a limit must not break the brotli responses that fit under it.
+{
+    my $enc   = IO::Compress::Brotli->create;
+    my $small = $enc->compress('hello world') . $enc->finish;
+
+    my $small_response = HTTP::Response->new(
+        200, 'OK',
+        HTTP::Headers->new(
+            Content_Type     => 'text/plain',
+            Content_Encoding => 'br',
+        ),
+        $small,
+    );
+    $small_response->max_body_size( 512 * 1024 );
+
+    is( $small_response->decoded_content( raise_error => 1 ), 'hello world',
+        'A brotli body well under the limit still decodes' )
+        or diag
+        "... using IO::Uncompress::Brotli version $IO::Uncompress::Brotli::VERSION";
+}
+
+done_testing();
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
Fixes #229.

`IO::Uncompress::Brotli::decompress` is a one-argument method, so passing the limit as a second argument was an XS usage error rather than a size cap. Every brotli response therefore failed to decode whenever a limit was set, regardless of size -- an 11-byte body died under a 1 GB limit.

`unbro($in, $max)` is the only brotli interface that accepts a size. It decodes into a buffer of that many octets, so the limit bounds the allocation directly rather than being checked after the fact. It does not commit the buffer up front: RSS stays flat decoding a small payload under a large limit.

One consequence worth knowing: `unbro` reports "output buffer too small" and "this is not valid brotli" identically, so the error cannot say which occurred and names both possibilities. That is unlike the gzip and bzip2 branches, which can tell the two apart.

## Test

`t/message-decode-brotlibomb.t` asserted only that decoding died when the body exceeded the limit. It did die -- on the arity error -- so it passed for the wrong reason since it was written. It now also asserts on the error message, and checks that a body *under* the limit still decodes, which is the case that was actually broken.

Verified the new assertions fail against the current `master` and pass here:

```
master     exit=2   (error-message assertion fails; under-limit test dies)
this branch exit=0
```

Note that `prove -I` is not enough to check this if you have `--lib` in a `.proverc`, since `./lib` then wins over `-I`. Run the file with `perl -I<path>` directly.

The plan is now `done_testing()` rather than a hardcoded count.

## Scope

Code, test and a `Changes` line only. `max_body_size` has no Pod on `master`, so nothing to update here.
